### PR TITLE
Restore app indexing to iOS

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -19,6 +19,12 @@ public partial class App : Application
         InitializeComponent();
 
         MainPage = new AppShell();
+
+        //TODO: this conditional compilation should be removed when this bug is fixed
+        //https://github.com/dotnet/maui/issues/12295
+#if IOS
+        (Application.Current as IApplicationController)?.SetAppIndexingProvider(new Microsoft.Maui.Controls.Compatibility.Platform.iOS.IOSAppIndexingProvider());
+#endif
     }
 
     protected override async void OnStart()

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -12,6 +12,7 @@ using Ifpa.Controls;
 using Shiny.Infrastructure;
 using PinballApi;
 using Maui.FixesAndWorkarounds;
+using Microsoft.Maui.Controls.Compatibility.Hosting;
 
 namespace Ifpa;
 
@@ -26,6 +27,7 @@ public static class MauiProgram
 
         builder
             .UseMauiApp<App>()
+            .UseMauiCompatibility()
             .UseMauiCommunityToolkit()
             .UseMauiMaps()
             .UseFluentMauiIcons()

--- a/ViewModels/PlayerDetailViewModel.cs
+++ b/ViewModels/PlayerDetailViewModel.cs
@@ -162,7 +162,7 @@ namespace Ifpa.ViewModels
             var entry = new AppLinkEntry
             {
                 Title = Name,
-                Description = Rank.ToString(),
+                Description = Rank.OrdinalSuffix(),
                 AppLinkUri = new Uri(url, UriKind.RelativeOrAbsolute),
                 IsLinkActive = true,
                 Thumbnail = ImageSource.FromUri(new Uri(PlayerAvatar, UriKind.RelativeOrAbsolute))
@@ -174,9 +174,9 @@ namespace Ifpa.ViewModels
             {
                 Application.Current.AppLinks.RegisterLink(entry);
             }
-            catch(ArgumentException ex)
+            catch(Exception ex)
             {
-                //TODO: resolve "No IAppIndexingProvider was provided" exception
+                Debug.WriteLine(ex.Message);
             }
         }
 

--- a/ViewModels/TournamentResultsViewModel.cs
+++ b/ViewModels/TournamentResultsViewModel.cs
@@ -61,8 +61,7 @@ namespace Ifpa.ViewModels
                 Description = TournamentDetails.EventName,
                 AppLinkUri = new Uri(url, UriKind.RelativeOrAbsolute),
                 IsLinkActive = true
-                //TODO: show thumbnail?
-                //Thumbnail = ImageSource.FromUri(new Uri(TournamentDetails., UriKind.RelativeOrAbsolute))
+                //No thumbnail for Tournament Results
             };
 
             entry.KeyValues.Add("contentType", "Tournament Result");
@@ -73,7 +72,7 @@ namespace Ifpa.ViewModels
             }
             catch(Exception ex)
             {
-                //TODO: No IAppIndexingProvider
+                Debug.WriteLine(ex);
             }
         }
     }


### PR DESCRIPTION
This restores adding app indexes. It still relies on deep linking, which is in progress
Fixes #46 