### PR TITLE
Fix Championship Series crashes for series with no years data

### DIFF
--- a/Caching/CachingPinballRankingApi.cs
+++ b/Caching/CachingPinballRankingApi.cs
@@ -59,15 +59,19 @@ namespace Ifpa.Caching
                                 "Cache miss for {Key}", ctx.OperationKey);
 
                             MainThread.BeginInvokeOnMainThread(() =>
-                                Toast.Make(Strings.Toast_Offline_NoCache,
-                                           ToastDuration.Long).Show());
+                            {
+                                try { Toast.Make(Strings.Toast_Offline_NoCache, ToastDuration.Long).Show(); }
+                                catch (Exception toastEx) { logger.LogWarning(toastEx, "Could not show offline toast"); }
+                            });
 
                             throw outcome.Exception!;   // no cache -> real error
                         }
 
                         MainThread.BeginInvokeOnMainThread(() =>
-                            Toast.Make(Strings.Toast_Offline_Cache,
-                                       ToastDuration.Long).Show());
+                        {
+                            try { Toast.Make(Strings.Toast_Offline_Cache, ToastDuration.Long).Show(); }
+                            catch (Exception toastEx) { logger.LogWarning(toastEx, "Could not show offline toast"); }
+                        });
                         return (T)val!;
                     },
                     onFallbackAsync: async (outcome, ctx) =>

--- a/ViewModels/ChampionshipSeriesListViewModel.cs
+++ b/ViewModels/ChampionshipSeriesListViewModel.cs
@@ -46,7 +46,9 @@ namespace Ifpa.ViewModels
         [RelayCommand]
         public async Task ViewChampionshipSeriesDetail(Series series)
         {
-            await Shell.Current.GoToAsync($"champ-series?seriesCode={SelectedChampionshipSeries.Code}&year={SelectedChampionshipSeries.Years.Max()}");
+            var years = SelectedChampionshipSeries.Years;
+            var year = years?.Count > 0 ? years.Max() : DateTime.Now.Year;
+            await Shell.Current.GoToAsync($"champ-series?seriesCode={SelectedChampionshipSeries.Code}&year={year}");
             SelectedChampionshipSeries = null;
         }
     }

--- a/ViewModels/ChampionshipSeriesViewModel.cs
+++ b/ViewModels/ChampionshipSeriesViewModel.cs
@@ -44,7 +44,8 @@ namespace Ifpa.ViewModels
                 var stateProvinceChampionshipSeries = await PinballRankingApi.GetSeriesOverallStanding(SeriesCode, Year);
                 var seriesDetails = await PinballRankingApi.GetSeries();
 
-                AvailableYears = seriesDetails.First(n => n.Code == SeriesCode).Years;
+                var matchedSeries = seriesDetails?.FirstOrDefault(n => n.Code == SeriesCode);
+                AvailableYears = matchedSeries?.Years?.Count > 0 ? matchedSeries.Years : new List<int> { Year };
 
                 if (stateProvinceChampionshipSeries != null)
                 {

--- a/Views/ChampionshipSeriesPage.xaml.cs
+++ b/Views/ChampionshipSeriesPage.xaml.cs
@@ -33,7 +33,8 @@ namespace Ifpa.Views
 
         private async void ToolbarItem_Clicked(object sender, EventArgs e)
         {
-            string action = await DisplayActionSheetAsync(Strings.PlayerChampionshipSeriesPage_YearPrompt, Strings.Cancel, null, ViewModel.AvailableYears.Select(n => n.ToString()).ToArray());
+            var years = ViewModel.AvailableYears ?? new List<int>();
+            string action = await DisplayActionSheetAsync(Strings.PlayerChampionshipSeriesPage_YearPrompt, Strings.Cancel, null, years.Select(n => n.ToString()).ToArray());
 
             if (int.TryParse(action, out var yearValue))
             {


### PR DESCRIPTION
## Summary

- **iOS/Android crash on new series (AUTCS, FINCS, UKCS, NCS)**: These series return no `years` field from the API. `ChampionshipSeriesListViewModel.ViewChampionshipSeriesDetail` called `Years.Max()` directly — `ArgumentNullException` unhandled, instant crash on tap. Fixed with null/empty guard, defaulting to current year.
- **`SeriesOverallResults` silently empty**: `ChampionshipSeriesViewModel.LoadItems` called `seriesDetails.First(...)` — would throw if `GetSeries()` returned null (both network and cache failed), aborting the try block before standings were assigned. Changed to `seriesDetails?.FirstOrDefault(...)` with fallback.
- **`AvailableYears` null in year picker**: `ChampionshipSeriesPage` toolbar handler called `.Select()` directly on `ViewModel.AvailableYears` with no null guard. Fixed with `?? new List<int>()`.
- **Toast crash in background job (Android)**: `CachingPinballRankingApi` called `Toast.Make().Show()` via `BeginInvokeOnMainThread` from a Shiny background job context where no foreground Activity exists. Wrapped in try/catch to prevent the `NullPointerException` from surfacing.

## Test plan

- [ ] Tap each of AUTCS, FINCS, UKCS, NCS from the Championship Series list — should navigate without crashing, defaulting to current year
- [ ] Verify year picker toolbar on a series detail page does not crash when `AvailableYears` is empty
- [ ] Verify background notification job does not crash when network is offline and cache is cold

🤖 Generated with [Claude Code](https://claude.com/claude-code)