### PR TITLE
Preserve AccessibilityNodeInfoCompat.set_Checked from IL linker

### DIFF
--- a/IfpaMaui.csproj
+++ b/IfpaMaui.csproj
@@ -136,6 +136,11 @@
       <AndroidResource Remove="Platforms\Android\Resources\values\strings.xml" />
     </ItemGroup>
 
+    <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+      <AndroidLinkDescription Include="Platforms\Android\LinkerPreserve.xml" />
+    </ItemGroup>
+
+
     <!-- Compile Directives / File Compile Types -->
     <ItemGroup>
         <None Remove="appsettings.json" />

--- a/Platforms/Android/LinkerPreserve.xml
+++ b/Platforms/Android/LinkerPreserve.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <!-- Preserve AccessibilityNodeInfoCompat.set_Checked, which is called by
+       MauiAccessibilityDelegateCompat but invisible to the static linker
+       since the call site is in a JNI callback. Without this, Release builds
+       strip the method and crash for users with accessibility services active. -->
+  <assembly fullname="Xamarin.AndroidX.Core">
+    <type fullname="AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat" preserve="nothing">
+      <method name="set_Checked" />
+    </type>
+  </assembly>
+</linker>


### PR DESCRIPTION
## Summary

- Adds `Platforms/Android/LinkerPreserve.xml` with an `AndroidLinkDescription` to preserve `AccessibilityNodeInfoCompat.set_Checked`
- `MauiAccessibilityDelegateCompat.OnInitializeAccessibilityNodeInfo` calls this method, but the call site is inside a JNI callback — invisible to static linker analysis — so Release builds strip it
- Results in `MissingMethodException: Method not found: void AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat.set_Checked(bool)` for any user with an accessibility service active (TalkBack, Switch Access, Voice Access, or any third-party accessibility service)
- Confirmed via customer log (player 112425, v3.4.7) showing crash loop triggered on every view render once accessibility service is active

## Test plan

- [ ] Customer (player 112425) confirms no crash after update with accessibility service active
- [ ] Verify Release build contains `set_Checked` in linked `Xamarin.AndroidX.Core.dll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)