### PR TITLE
Switch to TrimmerRootDescriptor for AccessibilityNodeInfoCompat.set_Checked

### DIFF
--- a/IfpaMaui.csproj
+++ b/IfpaMaui.csproj
@@ -137,7 +137,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-      <AndroidLinkDescription Include="Platforms\Android\LinkerPreserve.xml" />
+      <TrimmerRootDescriptor Include="Platforms\Android\LinkerPreserve.xml" />
     </ItemGroup>
 
 

--- a/Platforms/Android/LinkerPreserve.xml
+++ b/Platforms/Android/LinkerPreserve.xml
@@ -5,8 +5,8 @@
        since the call site is in a JNI callback. Without this, Release builds
        strip the method and crash for users with accessibility services active. -->
   <assembly fullname="Xamarin.AndroidX.Core">
-    <type fullname="AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat" preserve="nothing">
-      <method name="set_Checked" />
+    <type fullname="AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat">
+      <method signature="System.Void set_Checked(System.Boolean)" />
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
## Summary

- Switches from `AndroidLinkDescription` (old Xamarin format) to `TrimmerRootDescriptor` (correct .NET 6+ ILLink mechanism) for preserving `AccessibilityNodeInfoCompat.set_Checked`
- Also adds full method signature instead of just name for precise matching
- `AndroidLinkDescription` may not be reliably processed in .NET 10 MAUI; `TrimmerRootDescriptor` is the supported path forward

## Test plan

- [ ] Customer (player 112425) confirms no crash after update with accessibility service active
- [ ] Confirm log (4) crashes were on v3.4.7 (predates v3.4.8 by timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)