### PR TITLE
Fix accessibility crash by downgrading MAUI 10.0.70 to 10.0.51

### DIFF
--- a/IfpaMaui.csproj
+++ b/IfpaMaui.csproj
@@ -68,9 +68,9 @@
     <ItemGroup>
         <PackageReference Include="Eightbot.MauiNativePdfView" Version="1.0.8" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.70" />
-        <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="10.0.70" />
-        <PackageReference Include="CommunityToolkit.Maui" Version="14.1.1" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.51" />
+        <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="10.0.51" />
+        <PackageReference Include="CommunityToolkit.Maui" Version="14.0.1" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />


### PR DESCRIPTION
## Summary

- MAUI 10.0.70 introduced a regression where `AccessibilityNodeInfoCompat.set_Checked` is called via a JNI callback path that is invisible to the IL linker, causing the method to be stripped in Release builds
- Users with any accessibility service active (Voice Access, TalkBack, password managers, screen readers) crash immediately on launch or navigation
- Downgrading `Microsoft.Maui.Controls` and `Microsoft.Maui.Controls.Maps` from `10.0.70` to `10.0.51` resolves the crash; `CommunityToolkit.Maui` reverted from `14.1.1` to `14.0.1` to match

## Test plan

- [ ] Build Release on Android
- [ ] Enable Voice Access (`adb shell settings put secure enabled_accessibility_services com.google.android.apps.accessibility.voiceaccess/.JustSpeakService`)
- [ ] Navigate to a player profile then tournament history — should not crash
- [ ] Verify iOS build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)