### PR TITLE
Self-heal corrupt SQLite cache; fix CVE-2025-6965 (SQLite bump)

### DIFF
--- a/Caching/CachingPinballRankingApi.cs
+++ b/Caching/CachingPinballRankingApi.cs
@@ -26,11 +26,13 @@ namespace Ifpa.Caching
     {
         private readonly IPinballRankingApi onlineApi;
         private readonly ILogger<CachingPinballRankingApi> logger;
+        private readonly ILoggerFactory loggerFactory;
 
-        public CachingPinballRankingApi(IPinballRankingApi onlineApi, ILogger<CachingPinballRankingApi> logger)
+        public CachingPinballRankingApi(IPinballRankingApi onlineApi, ILogger<CachingPinballRankingApi> logger, ILoggerFactory loggerFactory)
         {
             this.onlineApi = onlineApi ?? throw new ArgumentNullException(nameof(onlineApi));
             this.logger = logger;
+            this.loggerFactory = loggerFactory;
         }
 
         private async Task<T> ExecuteWithCache<T>(string cacheKey, Func<Task<T>> fetch)
@@ -41,7 +43,7 @@ namespace Ifpa.Caching
             SQLiteCacheProvider<T> cache = null;
             try
             {
-                cache = new SQLiteCacheProvider<T>(Settings.CacheDatabasePath, logger);
+                cache = new SQLiteCacheProvider<T>(Settings.CacheDatabasePath, loggerFactory);
             }
             catch (Exception ex)
             {
@@ -100,8 +102,10 @@ namespace Ifpa.Caching
             var pipeline = Policy.WrapAsync(fallback, retry);
 
             // execute: if offline, retry will see NetworkUnavailableException
-            //    and skip directly to fallback; if online, fetch runs, then we cache it
-            var q = await pipeline.ExecuteAndCaptureAsync(async (ctx) =>
+            //    and skip directly to fallback; if online, fetch runs, then we cache it.
+            // ExecuteAsync (not ExecuteAndCaptureAsync) so a fallback that rethrows the real
+            // error propagates to the caller instead of being swallowed into a null result.
+            return await pipeline.ExecuteAsync(async (ctx) =>
             {
                 // network‐unavailable check
                 var access = Connectivity.Current.NetworkAccess;
@@ -111,20 +115,28 @@ namespace Ifpa.Caching
                 // real network call
                 var result = await fetch().ConfigureAwait(false);
 
-                // write‐through cache (skipped if the cache could not be initialized)
+                // write‐through cache (skipped if the cache could not be initialized).
+                // A cache-write failure (e.g. disk full) must never discard a successful live
+                // fetch, so swallow it here rather than let it escape and re-trigger the pipeline.
                 if (cache != null)
                 {
-                    await cache.PutAsync(ctx.OperationKey!,
-                                         result,
-                                         new Ttl(90.Days()),
-                                         CancellationToken.None,
-                                         continueOnCapturedContext: false);
+                    try
+                    {
+                        await cache.PutAsync(ctx.OperationKey!,
+                                             result,
+                                             new Ttl(90.Days()),
+                                             CancellationToken.None,
+                                             continueOnCapturedContext: false);
+                    }
+                    catch (Exception cacheEx)
+                    {
+                        logger.LogWarning(cacheEx, "Failed to write cache for {Key}; returning live result", ctx.OperationKey);
+                    }
                 }
 
                 return result;
             },
             new Context(cacheKey));
-            return q.Result;
         }
 
         public Task<List<CountryDetail>> GetCountriesList() =>

--- a/Caching/CachingPinballRankingApi.cs
+++ b/Caching/CachingPinballRankingApi.cs
@@ -35,7 +35,18 @@ namespace Ifpa.Caching
 
         private async Task<T> ExecuteWithCache<T>(string cacheKey, Func<Task<T>> fetch)
         {
-            var cache = new SQLiteCacheProvider<T>(Settings.CacheDatabasePath);
+            // Build the cache provider defensively. A corrupt cache self-heals inside the provider,
+            // but if it still can't be initialized (e.g. disk full) we degrade to a live-only fetch
+            // rather than letting the failure escape the pipeline and break every cached call.
+            SQLiteCacheProvider<T> cache = null;
+            try
+            {
+                cache = new SQLiteCacheProvider<T>(Settings.CacheDatabasePath, logger);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to initialize cache database; serving {Key} without cache", cacheKey);
+            }
 
             // Retry on non network‐unavailable errors
             var retry = Policy<T>
@@ -48,31 +59,35 @@ namespace Ifpa.Caching
                 .FallbackAsync(
                     async (outcome, ctx, ct) =>
                     {
-                        var (hit, val) = await cache.TryGetAsync(
-                                                ctx.OperationKey!,
-                                                ct,
-                                                continueOnCapturedContext: false);
-
-                        if (!hit)
+                        if (cache != null)
                         {
-                            logger.LogWarning(outcome.Exception,
-                                "Cache miss for {Key}", ctx.OperationKey);
+                            var (hit, val) = await cache.TryGetAsync(
+                                                    ctx.OperationKey!,
+                                                    ct,
+                                                    continueOnCapturedContext: false);
 
-                            MainThread.BeginInvokeOnMainThread(() =>
+                            if (hit)
                             {
-                                try { Toast.Make(Strings.Toast_Offline_NoCache, ToastDuration.Long).Show(); }
-                                catch (Exception toastEx) { logger.LogWarning(toastEx, "Could not show offline toast"); }
-                            });
-
-                            throw outcome.Exception!;   // no cache -> real error
+                                MainThread.BeginInvokeOnMainThread(() =>
+                                {
+                                    try { Toast.Make(Strings.Toast_Offline_Cache, ToastDuration.Long).Show(); }
+                                    catch (Exception toastEx) { logger.LogWarning(toastEx, "Could not show offline toast"); }
+                                });
+                                return (T)val!;
+                            }
                         }
+
+                        // No cache (unavailable or miss) -> surface the real error.
+                        logger.LogWarning(outcome.Exception,
+                            "Cache miss for {Key}", ctx.OperationKey);
 
                         MainThread.BeginInvokeOnMainThread(() =>
                         {
-                            try { Toast.Make(Strings.Toast_Offline_Cache, ToastDuration.Long).Show(); }
+                            try { Toast.Make(Strings.Toast_Offline_NoCache, ToastDuration.Long).Show(); }
                             catch (Exception toastEx) { logger.LogWarning(toastEx, "Could not show offline toast"); }
                         });
-                        return (T)val!;
+
+                        throw outcome.Exception!;
                     },
                     onFallbackAsync: async (outcome, ctx) =>
                     {
@@ -96,12 +111,15 @@ namespace Ifpa.Caching
                 // real network call
                 var result = await fetch().ConfigureAwait(false);
 
-                // write‐through cache
-                await cache.PutAsync(ctx.OperationKey!,
-                                     result,
-                                     new Ttl(90.Days()),
-                                     CancellationToken.None,
-                                     continueOnCapturedContext: false);
+                // write‐through cache (skipped if the cache could not be initialized)
+                if (cache != null)
+                {
+                    await cache.PutAsync(ctx.OperationKey!,
+                                         result,
+                                         new Ttl(90.Days()),
+                                         CancellationToken.None,
+                                         continueOnCapturedContext: false);
+                }
 
                 return result;
             },

--- a/Caching/SQLiteCacheProvider.cs
+++ b/Caching/SQLiteCacheProvider.cs
@@ -9,34 +9,25 @@ namespace Ifpa.Caching
     public class SQLiteCacheProvider<T> : IAsyncCacheProvider<T>, IAsyncDisposable
     {
         private readonly string _dbPath;
-        private readonly ILogger _logger;
+        private readonly ILogger<SQLiteCacheProvider<T>> _logger;
         private SQLiteAsyncConnection _db;
 
-        public SQLiteCacheProvider(string dbPath, ILogger logger = null)
+        public SQLiteCacheProvider(string dbPath, ILoggerFactory loggerFactory = null)
         {
             _dbPath = dbPath;
-            _logger = logger;
+            _logger = loggerFactory?.CreateLogger<SQLiteCacheProvider<T>>();
             _db = new SQLiteAsyncConnection(dbPath);
             // Initialize synchronously so a usable connection is guaranteed before first use.
             // A corrupt cache file self-heals here rather than throwing and bricking every cached call.
             Task.Run(InitializeAsync).GetAwaiter().GetResult();
         }
 
-        private async Task InitializeAsync()
-        {
-            try
+        private Task InitializeAsync() =>
+            RunWithRecovery(async () =>
             {
                 await _db.CreateTableAsync<CacheItem>();
                 await CleanupExpiredItems(); // Remove expired items on initialization
-            }
-            catch (Exception ex) when (IsCorruptionException(ex))
-            {
-                _logger?.LogWarning(ex,
-                    "Cache database at {Path} is corrupt; deleting and recreating it. Cached API data will be re-fetched; no user data is affected.",
-                    _dbPath);
-                await RecreateDatabaseAsync();
-            }
-        }
+            });
 
         private async Task CleanupExpiredItems()
         {
@@ -52,7 +43,8 @@ namespace Ifpa.Caching
         {
             return RunWithRecovery(async () =>
             {
-                await CleanupExpiredItems(); // Clean expired items before fetching
+                // Expired rows are purged once per provider construction (InitializeAsync); the
+                // expiration check below still guarantees an expired entry is never returned.
                 var item = await _db.FindAsync<CacheItem>(key);
 
                 if (item != null && item.Expiration > DateTime.UtcNow)
@@ -78,19 +70,18 @@ namespace Ifpa.Caching
                 Expiration = DateTime.UtcNow.Add(ttl.Timespan)
             };
 
-            return RunWithRecovery(async () =>
-            {
-                await _db.InsertOrReplaceAsync(item);
-                await CleanupExpiredItems(); // Enforce cleanup after insertion
-            });
+            return RunWithRecovery(() => _db.InsertOrReplaceAsync(item));
         }
 
-        public async Task ClearCache()
+        public Task ClearCache()
         {
-            // Delete all entries
-            await _db.DeleteAllAsync<CacheItem>();
-            // Run VACUUM to reclaim space and optimize the database
-            await _db.ExecuteAsync("VACUUM");
+            return RunWithRecovery(async () =>
+            {
+                // Delete all entries
+                await _db.DeleteAllAsync<CacheItem>();
+                // Run VACUUM to reclaim space and optimize the database
+                await _db.ExecuteAsync("VACUUM");
+            });
         }
 
         public async ValueTask DisposeAsync()
@@ -100,21 +91,8 @@ namespace Ifpa.Caching
 
         // Runs a cache operation, transparently rebuilding the database once if it is found to be
         // corrupt. The cache holds only re-fetchable API responses, so discarding it is always safe.
-        private async Task RunWithRecovery(Func<Task> operation)
-        {
-            try
-            {
-                await operation();
-            }
-            catch (Exception ex) when (IsCorruptionException(ex))
-            {
-                _logger?.LogWarning(ex,
-                    "Cache database at {Path} is corrupt; rebuilding and retrying. Cached API data will be re-fetched; no user data is affected.",
-                    _dbPath);
-                await RecreateDatabaseAsync();
-                await operation();
-            }
-        }
+        private Task RunWithRecovery(Func<Task> operation) =>
+            RunWithRecovery<object>(async () => { await operation(); return null; });
 
         private async Task<TResult> RunWithRecovery<TResult>(Func<Task<TResult>> operation)
         {

--- a/Caching/SQLiteCacheProvider.cs
+++ b/Caching/SQLiteCacheProvider.cs
@@ -1,4 +1,5 @@
-﻿using Ifpa.Models;
+using Ifpa.Models;
+using Microsoft.Extensions.Logging;
 using Polly.Caching;
 using SQLite;
 using System.Text.Json;
@@ -7,13 +8,34 @@ namespace Ifpa.Caching
 {
     public class SQLiteCacheProvider<T> : IAsyncCacheProvider<T>, IAsyncDisposable
     {
-        private readonly SQLiteAsyncConnection _db;
+        private readonly string _dbPath;
+        private readonly ILogger _logger;
+        private SQLiteAsyncConnection _db;
 
-        public SQLiteCacheProvider(string dbPath)
+        public SQLiteCacheProvider(string dbPath, ILogger logger = null)
         {
+            _dbPath = dbPath;
+            _logger = logger;
             _db = new SQLiteAsyncConnection(dbPath);
-            Task.Run(() => _db.CreateTableAsync<CacheItem>()).Wait();
-            Task.Run(CleanupExpiredItems).Wait(); // Remove expired items on initialization
+            // Initialize synchronously so a usable connection is guaranteed before first use.
+            // A corrupt cache file self-heals here rather than throwing and bricking every cached call.
+            Task.Run(InitializeAsync).GetAwaiter().GetResult();
+        }
+
+        private async Task InitializeAsync()
+        {
+            try
+            {
+                await _db.CreateTableAsync<CacheItem>();
+                await CleanupExpiredItems(); // Remove expired items on initialization
+            }
+            catch (Exception ex) when (IsCorruptionException(ex))
+            {
+                _logger?.LogWarning(ex,
+                    "Cache database at {Path} is corrupt; deleting and recreating it. Cached API data will be re-fetched; no user data is affected.",
+                    _dbPath);
+                await RecreateDatabaseAsync();
+            }
         }
 
         private async Task CleanupExpiredItems()
@@ -23,25 +45,28 @@ namespace Ifpa.Caching
 
         public async Task RemoveAsync(string key, CancellationToken cancellationToken = default)
         {
-            await _db.DeleteAsync<CacheItem>(key);
+            await RunWithRecovery(() => _db.DeleteAsync<CacheItem>(key));
         }
 
-        public async Task<(bool, T)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public Task<(bool, T)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            await CleanupExpiredItems(); // Clean expired items before fetching
-            var item = await _db.FindAsync<CacheItem>(key);
-
-            if (item != null && item.Expiration > DateTime.UtcNow)
+            return RunWithRecovery(async () =>
             {
-                // Deserialize to an object since type is not known at compile time
-                var value = JsonSerializer.Deserialize<T>(item.Value);
-                return (true, value);
-            }
+                await CleanupExpiredItems(); // Clean expired items before fetching
+                var item = await _db.FindAsync<CacheItem>(key);
 
-            return (false, default(T)); // Return false and null if no valid cache item is found
+                if (item != null && item.Expiration > DateTime.UtcNow)
+                {
+                    // Deserialize to an object since type is not known at compile time
+                    var value = JsonSerializer.Deserialize<T>(item.Value);
+                    return (true, value);
+                }
+
+                return (false, default(T)); // Return false and null if no valid cache item is found
+            });
         }
 
-        public async Task PutAsync(string key, T value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public Task PutAsync(string key, T value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (ttl.Timespan > Settings.CacheDuration)
                 ttl.Timespan = Settings.CacheDuration;
@@ -53,8 +78,11 @@ namespace Ifpa.Caching
                 Expiration = DateTime.UtcNow.Add(ttl.Timespan)
             };
 
-            await _db.InsertOrReplaceAsync(item);
-            await CleanupExpiredItems(); // Enforce cleanup after insertion
+            return RunWithRecovery(async () =>
+            {
+                await _db.InsertOrReplaceAsync(item);
+                await CleanupExpiredItems(); // Enforce cleanup after insertion
+            });
         }
 
         public async Task ClearCache()
@@ -68,6 +96,87 @@ namespace Ifpa.Caching
         public async ValueTask DisposeAsync()
         {
             await _db.CloseAsync();
+        }
+
+        // Runs a cache operation, transparently rebuilding the database once if it is found to be
+        // corrupt. The cache holds only re-fetchable API responses, so discarding it is always safe.
+        private async Task RunWithRecovery(Func<Task> operation)
+        {
+            try
+            {
+                await operation();
+            }
+            catch (Exception ex) when (IsCorruptionException(ex))
+            {
+                _logger?.LogWarning(ex,
+                    "Cache database at {Path} is corrupt; rebuilding and retrying. Cached API data will be re-fetched; no user data is affected.",
+                    _dbPath);
+                await RecreateDatabaseAsync();
+                await operation();
+            }
+        }
+
+        private async Task<TResult> RunWithRecovery<TResult>(Func<Task<TResult>> operation)
+        {
+            try
+            {
+                return await operation();
+            }
+            catch (Exception ex) when (IsCorruptionException(ex))
+            {
+                _logger?.LogWarning(ex,
+                    "Cache database at {Path} is corrupt; rebuilding and retrying. Cached API data will be re-fetched; no user data is affected.",
+                    _dbPath);
+                await RecreateDatabaseAsync();
+                return await operation();
+            }
+        }
+
+        private async Task RecreateDatabaseAsync()
+        {
+            // Release our handle so the underlying file can be deleted.
+            try { await _db.CloseAsync(); }
+            catch (Exception ex) { _logger?.LogDebug(ex, "Error closing corrupt cache connection (ignored)"); }
+
+            DeleteDatabaseFiles();
+
+            // Fresh, empty database with the schema in place.
+            _db = new SQLiteAsyncConnection(_dbPath);
+            await _db.CreateTableAsync<CacheItem>();
+        }
+
+        private void DeleteDatabaseFiles()
+        {
+            // SQLite may keep sidecar files (WAL / shared-memory / rollback journal); remove them all.
+            foreach (var suffix in new[] { string.Empty, "-wal", "-shm", "-journal" })
+            {
+                var path = _dbPath + suffix;
+                try
+                {
+                    if (File.Exists(path))
+                        File.Delete(path);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Could not delete corrupt cache file {Path}", path);
+                }
+            }
+        }
+
+        private static bool IsCorruptionException(Exception ex)
+        {
+            switch (ex)
+            {
+                case SQLiteException sqlite:
+                    // SQLITE_CORRUPT ("database disk image is malformed") or SQLITE_NOTADB.
+                    return sqlite.Result == SQLite3.Result.Corrupt
+                        || sqlite.Result == SQLite3.Result.NonDBFile;
+                case AggregateException aggregate:
+                    // .Wait()/.GetResult() wrap the SQLiteException; unwrap and inspect.
+                    return aggregate.Flatten().InnerExceptions.Any(IsCorruptionException);
+                default:
+                    return ex.InnerException != null && IsCorruptionException(ex.InnerException);
+            }
         }
     }
 

--- a/IfpaMaui.csproj
+++ b/IfpaMaui.csproj
@@ -84,9 +84,9 @@
         <PackageReference Include="Shiny.Extensions.Configuration" Version="4.0.1" />
         <PackageReference Include="Shiny.Jobs" Version="4.0.1" />
         <PackageReference Include="Shiny.Notifications" Version="4.0.1" />
-        <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
+        <PackageReference Include="sqlite-net-base" Version="1.9.172" />
         <PackageReference Include="SQLitePCLRaw.core" Version="3.0.3" />
-        <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
         <PackageReference Include="SQLitePCLRaw.provider.dynamic_cdecl" Version="3.0.3" />
         <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="3.0.3" />
         <PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.10" />

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -36,6 +36,11 @@ public static class MauiProgram
     public static MauiApp CreateMauiApp()
     {
 #if ANDROID
+        // Initialize the SQLitePCLRaw e_sqlite3 provider. This was previously handled implicitly by
+        // bundle_green's auto-init; after moving to sqlite-net-base + bundle_e_sqlite3 (patched SQLite,
+        // CVE-2025-6965) Android must init explicitly. iOS sets its own provider in AppDelegate.CreateMauiApp.
+        SQLitePCL.Batteries_V2.Init();
+
         FlurlHttp.Clients.WithDefaults(b => b.ConfigureInnerHandler(_ => new HttpClientHandler()));
 #endif
         var builder = MauiApp.CreateBuilder();

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -134,7 +134,8 @@ public static class MauiProgram
             var settings = sp.GetRequiredService<AppSettings>();
             var online = new PinballRankingApi(settings.IfpaApiKey);
             var logger = sp.GetRequiredService<ILogger<CachingPinballRankingApi>>();
-            return new CachingPinballRankingApi(online, logger);
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            return new CachingPinballRankingApi(online, logger, loggerFactory);
         });
 
         s.AddSingleton(Geocoding.Default);


### PR DESCRIPTION
## Summary

Two related SQLite fixes, discovered from a user's crash log where the app was effectively dead — every screen failed with `database disk image is malformed`.

### 1. Recover from a corrupt cache instead of bricking the app (`96de1c6`)
A malformed `app_cache.db3` threw from the `SQLiteCacheProvider` constructor **before** `ExecuteWithCache` built its Polly fallback pipeline, so every cached API call failed with no recovery path — permanent until reinstall.

- `SQLiteCacheProvider` now detects `SQLITE_CORRUPT` / `NONDBFILE` (at init or during any read/write) and deletes + recreates the cache DB, including the `-wal`/`-shm`/`-journal` siblings.
- The cache holds only re-fetchable API responses, so this is **data-safe** — favorites and preferences live in separate stores (`ActivityFeedSQLite.db3`, `Preferences`), which are never touched.
- `ExecuteWithCache` also degrades to a live network fetch if the cache can't be built, so a cache failure can never again escape the pipeline.

### 2. Fix CVE-2025-6965 — patched SQLite (`ab0be7f`)
`bundle_green` is frozen at `2.1.11` and drags in the vulnerable `lib.e_sqlite3` native binary (SQLite < 3.50.2, NU1903 / GHSA-2m69-gcr7-jv3q). Since `sqlite-net-pcl` depends on `bundle_green`, the bundle can't just be upgraded.

- `sqlite-net-pcl` → `sqlite-net-base` (drops the `bundle_green` chain)
- add `SQLitePCLRaw.bundle_e_sqlite3 3.0.3` (SQLite ≥ 3.50.4 via `SourceGear.sqlite3`)
- `sqlite-net-base` has no bundled provider, so Android now calls `SQLitePCL.Batteries_V2.Init()` explicitly in `MauiProgram` (iOS already sets its system-SQLite provider in `AppDelegate`).

## Verification

Reproduced the exact field failure on the Android emulator (corrupted page 1 of `app_cache.db3`, header preserved → genuine `SQLITE_CORRUPT`):

- **Recovery:** log shows `is corrupt; deleting and recreating`, then `Job Success` — 0 `[ERR]` entries (vs 4 in the field log). `ActivityFeedSQLite.db3` md5/size unchanged → favorites preserved.
- **CVE:** build clean, **NU1903 cleared**, no duplicate native lib, `bundle_green` out of the dependency graph.
- **Runtime:** first attempt crashed with a `SetProvider` error (caught by testing) — fixed by the explicit `Batteries_V2.Init()`; redeploy runs with healthy DB reads/writes.

## Caveats
- **iOS not build-tested** (requires Mac/CI). Safe by construction: `provider.sqlite3` is still referenced, the `AppDelegate` provider override is unchanged, and the `MauiProgram` change is `#if ANDROID`-only. Please confirm on an iOS build before release.
- Microsoft's own fix for this CVE (`Microsoft.Data.Sqlite`/EF Core) is targeted for 10.0.11 servicing, if you'd rather track upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
