### PR TITLE
Fix iOS 26 calendar bottom-sheet corner clipping; bump NativeCalendar to 1.0.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true # Disable the .NET first time experience
   DOTNET_CLI_TELEMETRY_OPTOUT: true       # Disable sending .NET CLI telemetry
   DOTNET_VERSION: '10.0.x'                # .NET version to use
-  XCODE_VERSION: '26.5'                   # Xcode version that supports iOS 26 for dotnet maui build
+  XCODE_VERSION: '26.6'                   # Xcode version that supports iOS 26 for dotnet maui build (26.6+ required by current .NET-for-iOS workload)
   IOS_FRAMEWORK: 'net10.0-ios'            # iOS framework target
   ANDROID_FRAMEWORK: 'net10.0-android'    # Android framework target
   

--- a/IfpaMaui.slnx
+++ b/IfpaMaui.slnx
@@ -2,5 +2,6 @@
   <Project Path="src/IfpaMaui/IfpaMaui.csproj">
     <Deploy />
   </Project>
+  <Project Path="src/The49.Maui.BottomSheet/The49.Maui.BottomSheet.csproj" />
   <Project Path="tests/IfpaMaui.Tests/IfpaMaui.Tests.csproj" />
 </Solution>

--- a/src/IfpaMaui/IfpaMaui.csproj
+++ b/src/IfpaMaui/IfpaMaui.csproj
@@ -76,7 +76,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />        
         <PackageReference Include="Plugin.Maui.CalendarStore" Version="5.0.0" />
-        <PackageReference Include="Plugin.Maui.NativeCalendar" Version="1.0.4" />
+        <PackageReference Include="Plugin.Maui.NativeCalendar" Version="1.0.6" />
         <PackageReference Include="Polly" Version="8.6.6" />
         <PackageReference Include="Scrutor" Version="7.0.0" />
         <PackageReference Include="Shiny.Core" Version="4.0.1" />

--- a/src/IfpaMaui/IfpaMaui.csproj
+++ b/src/IfpaMaui/IfpaMaui.csproj
@@ -97,9 +97,15 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-        <PackageReference Include="The49.Maui.BottomSheet" Version="8.0.3" />
-
         <PackageReference Include="PinballApi" Version="3.2.8" />
+    </ItemGroup>
+
+    <!-- Vendored fork of The49.Maui.BottomSheet with an iOS 26 floating-card fix
+         (medium-detent card was edge-attached with square bottom corners that the
+         rounded display clipped). Upstream is dormant (last release 8.0.3, 2024).
+         See src/The49.Maui.BottomSheet/VENDORED.md and upstream PR the49ltd/The49.Maui.BottomSheet#160. -->
+    <ItemGroup>
+        <ProjectReference Include="..\The49.Maui.BottomSheet\The49.Maui.BottomSheet.csproj" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/The49.Maui.BottomSheet/BottomSheet.cs
+++ b/src/The49.Maui.BottomSheet/BottomSheet.cs
@@ -1,0 +1,176 @@
+﻿#nullable enable
+
+using Microsoft.Maui.Controls;
+
+namespace The49.Maui.BottomSheet;
+
+public enum DismissOrigin
+{
+    Gesture,
+    Programmatic,
+}
+
+public partial class BottomSheet : ContentView
+{
+    public static readonly BindableProperty DetentsProperty = BindableProperty.Create(nameof(Detents), typeof(IList<Detent>), typeof(BottomSheet), default(IList<Detent>),
+        defaultValueCreator: bindable =>
+        {
+            return new List<Detent>();
+        });
+    public static readonly BindableProperty HasBackdropProperty = BindableProperty.Create(nameof(HasBackdrop), typeof(bool), typeof(BottomSheet), false);
+    public static readonly BindableProperty HasHandleProperty = BindableProperty.Create(nameof(HasHandle), typeof(bool), typeof(BottomSheet), false);
+    public static readonly BindableProperty HandleColorProperty = BindableProperty.Create(nameof(HandleColor), typeof(Color), typeof(BottomSheet), null);
+    public static readonly BindableProperty IsCancelableProperty = BindableProperty.Create(nameof(IsCancelable), typeof(bool), typeof(BottomSheet), true);
+    public static readonly BindableProperty SelectedDetentProperty = BindableProperty.Create(nameof(SelectedDetent), typeof(Detent), typeof(BottomSheet), null, BindingMode.TwoWay);
+    public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(double), typeof(BottomSheet), -1d);
+
+    //public event EventHandler<float> Sliding;
+    public event EventHandler<DismissOrigin>? Dismissed;
+    public event EventHandler? Showing;
+    public event EventHandler? Shown;
+
+    DismissOrigin _dismissOrigin = DismissOrigin.Gesture;
+
+    public IList<Detent> Detents
+    {
+        get => (IList<Detent>)GetValue(DetentsProperty);
+        set => SetValue(DetentsProperty, value);
+    }
+
+    public bool HasBackdrop
+    {
+        get => (bool)GetValue(HasBackdropProperty);
+        set => SetValue(HasBackdropProperty, value);
+    }
+
+    public bool HasHandle
+    {
+        get => (bool)GetValue(HasHandleProperty);
+        set => SetValue(HasHandleProperty, value);
+    }
+
+    public Color? HandleColor
+    {
+        get => (Color?)GetValue(HandleColorProperty);
+        set => SetValue(HandleColorProperty, value);
+    }
+
+    public bool IsCancelable
+    {
+        get => (bool)GetValue(IsCancelableProperty);
+        set => SetValue(IsCancelableProperty, value);
+    }
+
+    public Detent? SelectedDetent
+    {
+        get => (Detent?)GetValue(SelectedDetentProperty);
+        set => SetValue(SelectedDetentProperty, value);
+    }
+
+    public double CornerRadius
+    {
+        get => (double)GetValue(CornerRadiusProperty);
+        set => SetValue(CornerRadiusProperty, value);
+    }
+
+    public BottomSheet() : base()
+    {
+        Resources.Add(new Style(typeof(Label)));
+    }
+
+    public Task ShowAsync(bool animated = true)
+    {
+        var window = Application.Current?.Windows[0];
+        if (window is null)
+        {
+            return Task.CompletedTask;
+        }
+        return ShowAsync(window, animated);
+    }
+
+    public Task ShowAsync(Window window, bool animated = true)
+    {
+        var completionSource = new TaskCompletionSource();
+        void OnShown(object? sender, EventArgs e)
+        {
+            Shown -= OnShown;
+            completionSource.SetResult();
+        }
+        Shown += OnShown;
+
+        if (SelectedDetent is null)
+        {
+            SelectedDetent = GetDefaultDetent();
+        }
+        window.AddLogicalChild(this);
+        BottomSheetManager.Show(window, this, animated);
+        return completionSource.Task;
+    }
+
+    public Task DismissAsync(bool animated = true)
+    {
+        _dismissOrigin = DismissOrigin.Programmatic;
+        var completionSource = new TaskCompletionSource();
+        void OnDismissed(object? sender, DismissOrigin origin)
+        {
+            Dismissed -= OnDismissed;
+            completionSource.SetResult();
+        }
+        Dismissed += OnDismissed;
+        Handler?.Invoke(nameof(DismissAsync), animated);
+        return completionSource.Task;
+    }
+
+    internal IEnumerable<Detent> GetEnabledDetents()
+    {
+        var enabledDetents = Detents.Where(d => d.IsEnabled);
+
+        if (enabledDetents.Count() == 0)
+        {
+            return new List<Detent> { new ContentDetent() };
+        }
+        return enabledDetents;
+    }
+
+    internal Detent? GetDefaultDetent()
+    {
+        var detents = GetEnabledDetents();
+        var detent = SelectedDetent;
+        if (SelectedDetent is not null)
+        {
+            return SelectedDetent;
+        }
+        return detents.FirstOrDefault(d => d.IsDefault);
+    }
+
+    internal void NotifyDismissed()
+    {
+        this.Parent.RemoveLogicalChild(this);
+        Dismissed?.Invoke(this, _dismissOrigin);
+    }
+
+    internal Brush? BackgroundBrush
+    {
+        get
+        {
+            if (!Background.IsEmpty)
+            {
+                return Background;
+            }
+            if (BackgroundColor.IsNotDefault())
+            {
+                return new SolidColorBrush(BackgroundColor);
+            }
+            return null;
+        }
+    }
+
+    internal void NotifyShowing()
+    {
+        Showing?.Invoke(this, EventArgs.Empty);
+    }
+    internal void NotifyShown()
+    {
+        Shown?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/The49.Maui.BottomSheet/BottomSheetHandler.cs
+++ b/src/The49.Maui.BottomSheet/BottomSheetHandler.cs
@@ -1,0 +1,87 @@
+﻿#nullable enable
+using Microsoft.Maui.Handlers;
+
+#if IOS
+using PlatformView = UIKit.UIView;
+#elif ANDROID
+using PlatformView = Android.Views.View;
+#else
+using PlatformView = System.Object;
+#endif
+
+
+namespace The49.Maui.BottomSheet;
+
+public partial class BottomSheetHandler : ContentViewHandler
+{
+    public static new IPropertyMapper<BottomSheet, BottomSheetHandler> Mapper =
+        new PropertyMapper<BottomSheet, BottomSheetHandler>(ContentViewHandler.Mapper)
+        {
+            [nameof(IContentView.Background)] = MapBackground,
+            [nameof(BottomSheet.HandleColor)] = MapHandleColor,
+            [nameof(BottomSheet.HasBackdrop)] = MapHasBackdrop,
+            [nameof(BottomSheet.SelectedDetent)] = MapSelectedDetent,
+            [nameof(BottomSheet.CornerRadius)] = MapCornerRadius,
+        };
+
+    static void MapCornerRadius(BottomSheetHandler handler, BottomSheet sheet)
+    {
+        handler.PlatformUpdateCornerRadius(sheet);
+    }
+
+    static void MapHasBackdrop(BottomSheetHandler handler, BottomSheet sheet)
+    {
+        handler.PlatformUpdateHasBackdrop(sheet);
+    }
+
+    static void MapHandleColor(BottomSheetHandler handler, BottomSheet sheet)
+    {
+        handler.PlatformUpdateHandleColor(sheet);
+    }
+
+    public static new CommandMapper<BottomSheet, BottomSheetHandler> CommandMapper =
+        new(ContentViewHandler.CommandMapper)
+        {
+            [nameof(BottomSheet.DismissAsync)] = MapDismiss,
+        };
+
+    static void MapDismiss(BottomSheetHandler handler, BottomSheet view, object? request)
+    {
+        handler.Dismiss(view, request ?? false);
+    }
+
+    public static void MapSelectedDetent(BottomSheetHandler handler, BottomSheet view)
+    {
+        handler.PlatformMapSelectedDetent(view);
+    }
+
+    internal void UpdateSelectedDetent(BottomSheet view)
+    {
+        PlatformUpdateSelectedDetent(view);
+    }
+
+    partial void PlatformMapSelectedDetent(BottomSheet view);
+    partial void PlatformUpdateHandleColor(BottomSheet view);
+    partial void PlatformUpdateHasBackdrop(BottomSheet view);
+    partial void PlatformUpdateSelectedDetent(BottomSheet view);
+    partial void PlatformUpdateCornerRadius(BottomSheet view);
+    partial void Dismiss(BottomSheet view, object request);
+
+    public BottomSheetHandler() : base(Mapper, CommandMapper)
+    {
+    }
+
+    public BottomSheetHandler(IPropertyMapper? mapper)
+        : base(mapper ?? Mapper, CommandMapper)
+    {
+    }
+
+    public BottomSheetHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
+    {
+    }
+
+    new BottomSheet? VirtualView { get; }
+    new PlatformView? PlatformView { get; }
+
+}

--- a/src/The49.Maui.BottomSheet/BottomSheetManager.cs
+++ b/src/The49.Maui.BottomSheet/BottomSheetManager.cs
@@ -1,0 +1,18 @@
+﻿namespace The49.Maui.BottomSheet;
+
+internal partial class BottomSheetManager
+{
+    internal static void Show(Window window, BottomSheet sheet, bool animated)
+    {
+        PlatformShow(window, sheet, animated);
+        sheet.SizeChanged += OnSizeChanged;
+    }
+
+    static void OnSizeChanged(object sender, EventArgs e)
+    {
+        PlatformLayout((BottomSheet)sender);
+    }
+
+    static partial void PlatformShow(Window window, BottomSheet sheet, bool animated);
+    static partial void PlatformLayout(BottomSheet sheet);
+}

--- a/src/The49.Maui.BottomSheet/Hosting/MauiAppBuilderExtensions.cs
+++ b/src/The49.Maui.BottomSheet/Hosting/MauiAppBuilderExtensions.cs
@@ -1,0 +1,13 @@
+﻿[assembly: XmlnsDefinition("https://schemas.the49.com/dotnet/2023/maui", "The49.Maui.BottomSheet")]
+namespace The49.Maui.BottomSheet;
+
+public static class MauiAppBuilderExtensions
+{
+    public static MauiAppBuilder UseBottomSheet(this MauiAppBuilder builder)
+    {
+        return builder.ConfigureMauiHandlers(cfg =>
+        {
+            cfg.AddHandler<BottomSheet, BottomSheetHandler>();
+        });
+    }
+}

--- a/src/The49.Maui.BottomSheet/LICENSE.md
+++ b/src/The49.Maui.BottomSheet/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 The49 Ltd. (https://the49.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/The49.Maui.BottomSheet/Models/AnchorDetent.cs
+++ b/src/The49.Maui.BottomSheet/Models/AnchorDetent.cs
@@ -1,0 +1,19 @@
+﻿using Maui.BindableProperty.Generator.Core;
+
+namespace The49.Maui.BottomSheet;
+
+public partial class AnchorDetent: Detent
+{
+    double _height = 0;
+#pragma warning disable CS0169
+    [AutoBindable]
+    readonly VisualElement anchor;
+#pragma warning restore CS0169
+    public override double GetHeight(BottomSheet page, double maxSheetHeight)
+    {
+        UpdateHeight(page, maxSheetHeight);
+        return _height;
+    }
+
+    partial void UpdateHeight(BottomSheet page, double maxSheetHeight);
+}

--- a/src/The49.Maui.BottomSheet/Models/ContentDetent.cs
+++ b/src/The49.Maui.BottomSheet/Models/ContentDetent.cs
@@ -1,0 +1,23 @@
+﻿namespace The49.Maui.BottomSheet;
+
+public partial class ContentDetent : Detent
+{
+    public override double GetHeight(BottomSheet page, double maxSheetHeight)
+    {
+        if (page?.Content is null)
+        {
+            return maxSheetHeight;
+        }
+
+        // I left this code as comment because it might be useful for future reference, but it's not used
+        //if (page.Content is ScrollView sv)
+        //{
+        //    var s = sv.Content.Measure(page.Window.Width - page.Padding.HorizontalThickness, maxSheetHeight);
+        //}
+
+        // HACK: from 'page.Window.Width' to 'page.Window?.Width ?? page.Width' 
+        var r = page.Content.Measure(page.Window?.Width ?? page.Width - page.Padding.HorizontalThickness, maxSheetHeight);
+
+        return Math.Min(maxSheetHeight, r.Height + page.Padding.VerticalThickness);
+    }
+}

--- a/src/The49.Maui.BottomSheet/Models/Detent.cs
+++ b/src/The49.Maui.BottomSheet/Models/Detent.cs
@@ -1,0 +1,15 @@
+﻿using Maui.BindableProperty.Generator.Core;
+
+namespace The49.Maui.BottomSheet;
+
+public abstract partial class Detent : BindableObject
+{
+#pragma warning disable CS0169
+    [AutoBindable(DefaultValue = "true")]
+    readonly bool isEnabled;
+
+    [AutoBindable]
+    readonly bool isDefault;
+#pragma warning restore CS0169
+    public abstract double GetHeight(BottomSheet page, double maxSheetHeight);
+}

--- a/src/The49.Maui.BottomSheet/Models/DetentsCollection.cs
+++ b/src/The49.Maui.BottomSheet/Models/DetentsCollection.cs
@@ -1,0 +1,5 @@
+﻿namespace The49.Maui.BottomSheet;
+
+public class DetentsCollection: List<Detent>
+{
+}

--- a/src/The49.Maui.BottomSheet/Models/FullscreenDetent.cs
+++ b/src/The49.Maui.BottomSheet/Models/FullscreenDetent.cs
@@ -1,0 +1,9 @@
+﻿namespace The49.Maui.BottomSheet;
+
+public partial class FullscreenDetent : Detent
+{
+    public override double GetHeight(BottomSheet page, double maxSheetHeight)
+    {
+        return maxSheetHeight;
+    }
+}

--- a/src/The49.Maui.BottomSheet/Models/HeightDetent.cs
+++ b/src/The49.Maui.BottomSheet/Models/HeightDetent.cs
@@ -1,0 +1,16 @@
+﻿using Maui.BindableProperty.Generator.Core;
+
+namespace The49.Maui.BottomSheet;
+
+[ContentProperty(nameof(Height))]
+public partial class HeightDetent : Detent
+{
+#pragma warning disable CS0169
+    [AutoBindable]
+    readonly double height;
+#pragma warning restore CS0169
+    public override double GetHeight(BottomSheet page, double maxSheetHeight)
+    {
+        return Height;
+    }
+}

--- a/src/The49.Maui.BottomSheet/Models/MediumDetent.cs
+++ b/src/The49.Maui.BottomSheet/Models/MediumDetent.cs
@@ -1,0 +1,9 @@
+﻿namespace The49.Maui.BottomSheet;
+
+public class MediumDetent : RatioDetent
+{
+    public MediumDetent() : base()
+    {
+        Ratio = .5f;
+    }
+}

--- a/src/The49.Maui.BottomSheet/Models/RatioDetent.cs
+++ b/src/The49.Maui.BottomSheet/Models/RatioDetent.cs
@@ -1,0 +1,16 @@
+﻿using Maui.BindableProperty.Generator.Core;
+
+namespace The49.Maui.BottomSheet;
+
+[ContentProperty(nameof(Ratio))]
+public partial class RatioDetent : Detent
+{
+#pragma warning disable CS0169
+    [AutoBindable]
+    readonly float ratio;
+#pragma warning restore CS0169
+    public override double GetHeight(BottomSheet page, double maxSheetHeight)
+    {
+        return maxSheetHeight * Ratio;
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheet.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheet.cs
@@ -1,0 +1,6 @@
+﻿namespace The49.Maui.BottomSheet;
+
+public partial class BottomSheet
+{
+    public BottomSheetController Controller { get; set; }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetBackdrop.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetBackdrop.cs
@@ -1,0 +1,34 @@
+﻿using Android.Animation;
+using Android.Content;
+using Android.Graphics.Drawables;
+using AView = Android.Views.View;
+
+namespace The49.Maui.BottomSheet;
+internal class BottomSheetBackdrop : AView
+{
+    public BottomSheetBackdrop(Context context) : base(context)
+    {
+        Clickable = true;
+        Background = new ColorDrawable(Android.Graphics.Color.Black);
+        Alpha = .5f;
+    }
+
+    public void AnimateIn()
+    {
+        var alphaAnimator = ObjectAnimator.OfFloat(this, "alpha", 0f, .5f);
+
+        alphaAnimator.SetDuration(Context.Resources.GetInteger(Resource.Integer.bottom_sheet_slide_duration));
+
+        alphaAnimator.Start();
+    }
+
+    public void AnimateOut()
+    {
+        var alphaAnimator = ObjectAnimator.OfFloat(this, "alpha", .5f, 0f);
+
+        alphaAnimator.SetDuration(Context.Resources.GetInteger(Resource.Integer.bottom_sheet_slide_duration));
+
+        alphaAnimator.Start();
+    }
+}
+

--- a/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetCallback.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetCallback.cs
@@ -1,0 +1,22 @@
+﻿using AView = Android.Views.View;
+using Google.Android.Material.BottomSheet;
+
+namespace The49.Maui.BottomSheet;
+
+public class BottomSheetCallback : BottomSheetBehavior.BottomSheetCallback
+{
+    readonly BottomSheet _page;
+
+    public event EventHandler StateChanged;
+    public BottomSheetCallback(BottomSheet page) : base()
+    {
+        _page = page;
+    }
+    public override void OnSlide(AView bottomSheet, float newState)
+    {}
+
+    public override void OnStateChanged(AView view, int newState)
+    {
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetContainer.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetContainer.cs
@@ -1,0 +1,28 @@
+﻿using Android.Views;
+using Android.Widget;
+using AView = Android.Views.View;
+using Android.Content;
+
+namespace The49.Maui.BottomSheet;
+
+internal class BottomSheetContainer : FrameLayout
+{
+    AView _contentView;
+    BottomSheetBackdrop _backdrop;
+
+    public AView ContentView => _contentView;
+    public BottomSheetBackdrop Backdrop => _backdrop;
+
+    public BottomSheetContainer(Context context, AView contentView) : base(context)
+    {
+        _contentView = contentView;
+        _backdrop = new BottomSheetBackdrop(context);
+        AddView(_backdrop);
+        AddView(_contentView);
+    }
+
+    internal void SetBackdropVisibility(bool hasBackdrop)
+    {
+        _backdrop.Visibility = hasBackdrop ? ViewStates.Visible : ViewStates.Gone;
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetController.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetController.cs
@@ -1,0 +1,651 @@
+﻿using Android.Views;
+using Microsoft.Maui.Platform;
+using Google.Android.Material.BottomSheet;
+using Android.Widget;
+using Android.Content.Res;
+using AView = Android.Views.View;
+using AWindow = Android.Views.Window;
+using AndroidX.Core.View;
+using AndroidX.AppCompat.App;
+using Google.Android.Material.Internal;
+using Google.Android.Material.Color;
+using Android.Graphics.Drawables;
+using Android.Content;
+using Insets = AndroidX.Core.Graphics.Insets;
+
+namespace The49.Maui.BottomSheet;
+
+public class BottomSheetController
+{
+    class EdgeToEdgeCallback : BottomSheetBehavior.BottomSheetCallback
+    {
+        private BottomSheetController _controller;
+        WindowInsetsCompat _insetsCompat;
+
+        AWindow _window;
+        bool _isStatusBarLight;
+
+        public EdgeToEdgeCallback(BottomSheetController controller, WindowInsetsCompat insetsCompat)
+        {
+            _controller = controller;
+            _insetsCompat = insetsCompat;
+            SetPaddingForPosition(_controller._frame);
+        }
+
+        public override void OnStateChanged(AView bottomSheet, int p1)
+        {
+            SetPaddingForPosition(bottomSheet);
+        }
+
+        public override void OnSlide(AView bottomSheet, float newState)
+        {
+            SetPaddingForPosition(bottomSheet);
+        }
+
+        public void SetWindow(AWindow window)
+        {
+            if (_window == window)
+            {
+                return;
+            }
+            _window = window;
+            if (window != null)
+            {
+                WindowInsetsControllerCompat insetsController = WindowCompat.GetInsetsController(window, window.DecorView);
+                _isStatusBarLight = insetsController.AppearanceLightStatusBars;
+            }
+        }
+
+        int TopInset
+        {
+            get
+            {
+                if (OperatingSystem.IsAndroidVersionAtLeast(30))
+                {
+                    return _insetsCompat.GetInsetsIgnoringVisibility(Android.Views.WindowInsets.Type.SystemBars()).Top;
+                }
+#pragma warning disable CS0618
+                return _insetsCompat.StableInsetTop;
+#pragma warning restore CS0618
+            }
+        }
+
+        void SetPaddingForPosition(AView bottomSheet)
+        {
+            var keyboardHeight = _insetsCompat.GetInsets(WindowInsetsCompat.Type.Ime()).Bottom;
+            if (bottomSheet.Top < TopInset)
+            {
+                // If the bottomsheet is light, we should set light status bar so the icons are visible
+                // since the bottomsheet is now under the status bar.
+                if (_window != null)
+                {
+                    EdgeToEdgeUtils.SetLightStatusBar(
+                        _window, !_controller._isBackgroundLight.HasValue ? _isStatusBarLight : _controller._isBackgroundLight.Value);
+                }
+                // Smooth transition into status bar when drawing edge to edge.
+                bottomSheet.SetPadding(
+                    bottomSheet.PaddingLeft,
+                    TopInset - bottomSheet.Top,
+                    bottomSheet.PaddingRight,
+                    keyboardHeight);
+            }
+            else if (bottomSheet.Top != 0)
+            {
+                // Reset the status bar icons to the original color because the bottomsheet is not under the
+                // status bar.
+                if (_window != null)
+                {
+                    EdgeToEdgeUtils.SetLightStatusBar(_window, _isStatusBarLight);
+                }
+                bottomSheet.SetPadding(
+                    bottomSheet.PaddingLeft,
+                    0,
+                    bottomSheet.PaddingRight,
+                    keyboardHeight);
+            }
+        }
+    }
+    class EdgeToEdgeListener : Java.Lang.Object, IOnApplyWindowInsetsListener
+    {
+        BottomSheetController _controller;
+        EdgeToEdgeCallback _edgeToEdgeCallback;
+        public EdgeToEdgeListener(BottomSheetController controller)
+        {
+            _controller = controller;
+        }
+        public WindowInsetsCompat OnApplyWindowInsets(AView v, WindowInsetsCompat insets)
+        {
+            if (_edgeToEdgeCallback is not null)
+            {
+                _controller.Behavior.RemoveBottomSheetCallback(_edgeToEdgeCallback);
+            }
+
+            if (insets != null)
+            {
+                _edgeToEdgeCallback = new EdgeToEdgeCallback(_controller, insets);
+                _edgeToEdgeCallback.SetWindow(((AppCompatActivity)_controller._mauiContext.Context).Window);
+                _controller.Behavior.AddBottomSheetCallback(_edgeToEdgeCallback);
+                _controller.CalculateHeights(_controller.GetAvailableHeight());
+                _controller.ResizeVirtualView();
+                _controller.Layout();
+            }
+
+
+            return ViewCompat.OnApplyWindowInsets(v, insets);
+        }
+    }
+
+    class BottomSheetInsetsAnimationCallback : WindowInsetsAnimationCompat.Callback
+    {
+        readonly BottomSheetController _controller;
+        int _startHeight;
+        int _endHeight;
+
+        public BottomSheetInsetsAnimationCallback(BottomSheetController controller) : base(DispatchModeStop)
+        {
+            _controller = controller;
+        }
+
+        public override WindowInsetsAnimationCompat.BoundsCompat OnStart(WindowInsetsAnimationCompat animation, WindowInsetsAnimationCompat.BoundsCompat bounds)
+        {
+            _endHeight = _controller.WindowInsets.GetInsets(WindowInsetsCompat.Type.Ime()).Bottom;
+            _controller._frame.TranslationY = _endHeight - _startHeight;
+            return bounds;
+        }
+
+        public override void OnPrepare(WindowInsetsAnimationCompat animation)
+        {
+            _startHeight = _controller.WindowInsets.GetInsets(WindowInsetsCompat.Type.Ime()).Bottom;
+            base.OnPrepare(animation);
+        }
+
+        public override WindowInsetsCompat OnProgress(WindowInsetsCompat insets, IList<WindowInsetsAnimationCompat> runningAnimations)
+        {
+            WindowInsetsAnimationCompat imeAnimation = null;
+            foreach (var animation in runningAnimations)
+            {
+                if ((animation.TypeMask & WindowInsetsCompat.Type.Ime()) != 0)
+                {
+                    imeAnimation = animation;
+                    break;
+                }
+            }
+            if (imeAnimation != null)
+            {
+                _controller._frame.TranslationY = (_endHeight - _startHeight) * (1 - imeAnimation.InterpolatedFraction);
+            }
+            return insets;
+        }
+    }
+
+    static StayOnFrontView _stayOnFront;
+
+    internal IDictionary<Detent, int> _states;
+    internal IDictionary<Detent, double> _heights;
+    bool _isDuringShowingAnimation = false;
+    BottomSheetBehavior _behavior;
+    ViewGroup _frame;
+    BottomSheetContainer _windowContainer;
+    BottomSheetDragHandleView _handle;
+    bool? _isBackgroundLight;
+
+    public ViewGroup Frame => _frame;
+
+    public BottomSheetBehavior Behavior => _behavior;
+
+    IMauiContext _mauiContext { get; }
+    BottomSheet _sheet { get; }
+
+    public bool UseNavigationBarArea { get; set; } = false;
+
+    int BottomInset => UseNavigationBarArea ? 0 : Insets.Bottom;
+
+    public BottomSheetController(IMauiContext windowMauiContext, BottomSheet sheet)
+    {
+        _mauiContext = windowMauiContext;
+        _sheet = sheet;
+    }
+
+    internal void CalculateHeights(double maxSheetHeight)
+    {
+        var detents = _sheet.GetEnabledDetents().ToList();
+
+        _heights = new Dictionary<Detent, double>();
+
+        foreach (var detent in detents)
+        {
+            _heights.Add(detent, detent.GetHeight(_sheet, maxSheetHeight));
+        }
+    }
+
+    internal void CalculateStates()
+    {
+        var heights = _heights.OrderByDescending(kv => kv.Value).ToList();
+
+        _states = new Dictionary<Detent, int>();
+
+        if (heights.Count == 1)
+        {
+            _states.Add(heights[0].Key, BottomSheetBehavior.StateCollapsed);
+        }
+        else if (heights.Count == 2)
+        {
+            _states.Add(heights[0].Key, BottomSheetBehavior.StateExpanded);
+            _states.Add(heights[1].Key, BottomSheetBehavior.StateCollapsed);
+        }
+        else if (heights.Count == 3)
+        {
+            _states.Add(heights[0].Key, BottomSheetBehavior.StateExpanded);
+            _states.Add(heights[1].Key, BottomSheetBehavior.StateHalfExpanded);
+            _states.Add(heights[2].Key, BottomSheetBehavior.StateCollapsed);
+        }
+    }
+
+    internal int GetStateForDetent(Detent detent)
+    {
+        if (detent is null || !_states.ContainsKey(detent))
+        {
+            return -1;
+        }
+        return _states[detent];
+    }
+    internal Detent GetDetentForState(int state)
+    {
+        return _states.FirstOrDefault(kv => kv.Value == state).Key;
+    }
+
+    public void Dismiss(bool animated)
+    {
+
+        if (animated)
+        {
+            _windowContainer?.Backdrop.AnimateOut();
+            Behavior.Hideable = true;
+            Behavior.State = BottomSheetBehavior.StateHidden;
+        }
+        else
+        {
+            Dispose();
+            _sheet.NotifyDismissed();
+        }
+    }
+
+    void Dispose()
+    {
+        _frame.LayoutChange -= OnLayoutChange;
+        _windowContainer.RemoveFromParent();
+    }
+
+    public void Layout()
+    {
+        LayoutDetents(_heights, GetAvailableHeight());
+    }
+
+    internal void UpdateBackground()
+    {
+        Paint paint = _sheet.BackgroundBrush;
+        if (Frame is not null)
+        {
+            if (_sheet.CornerRadius != -1)
+            {
+                SheetRadiusDrawable drawable;
+                if (Frame.Background is not SheetRadiusDrawable)
+                {
+                    drawable = new SheetRadiusDrawable();
+                    Frame.Background = drawable;
+                }
+                else
+                {
+                    drawable = (SheetRadiusDrawable)Frame.Background;
+                }
+                drawable.SetCornerRadius(Frame.Context.ToPixels(_sheet.CornerRadius));
+            }
+            if (paint is not null)
+            {
+                var platformColor = paint.ToColor().ToPlatform();
+                if (Frame.Background is SheetRadiusDrawable sheetDrawable)
+                {
+                    sheetDrawable.SetColor(platformColor);
+                }
+                else
+                {
+                    Frame.BackgroundTintList = ColorStateList.ValueOf(platformColor);
+                }
+            }
+        }
+        // Try to find the background color to automatically change the status bar icons so they will
+        // still be visible when the bottomsheet slides underneath the status bar.
+        ColorStateList backgroundTint = ViewCompat.GetBackgroundTintList(Frame);
+
+        if (backgroundTint != null)
+        {
+            // First check for a tint
+            _isBackgroundLight = MaterialColors.IsColorLight(backgroundTint.DefaultColor);
+        }
+        else if (Frame.Background is ColorDrawable)
+        {
+            // Then check for the background color
+            _isBackgroundLight = MaterialColors.IsColorLight(((ColorDrawable)Frame.Background).Color);
+        }
+        else
+        {
+            // Otherwise don't change the status bar color
+            _isBackgroundLight = null;
+        }
+    }
+
+    public void UpdateHandleColor()
+    {
+        if (_handle is null)
+        {
+            return;
+        }
+        if (_sheet.HandleColor is not null)
+        {
+            _handle.SetColorFilter(_sheet.HandleColor.ToPlatform());
+        }
+    }
+
+    static void EnsureStayOnFrontView(Context context)
+    {
+        if (_stayOnFront is null || !_stayOnFront.IsAttachedToWindow)
+        {
+            _stayOnFront = new StayOnFrontView(context);
+            var window = ((AppCompatActivity)context).Window;
+            var parentView = window?.DecorView as ViewGroup;
+            parentView.AddView(_stayOnFront);
+        }
+    }
+
+    void EnsureWindowContainer()
+    {
+        EnsureStayOnFrontView(_mauiContext.Context);
+        if (_windowContainer is null)
+        {
+            var container = (FrameLayout)AView.Inflate(_mauiContext.Context, Resource.Layout.the49_maui_bottom_sheet_design, null);
+
+            container.ViewAttachedToWindow += ContainerAttachedToWindow;
+            container.ViewDetachedFromWindow += ContainerDetachedFromWindow;
+
+            _windowContainer = new BottomSheetContainer(_mauiContext.Context, container);
+            _windowContainer.Backdrop.Click += BackdropClicked;
+
+            _frame = (FrameLayout)container.FindViewById(Resource.Id.design_bottom_sheet);
+
+            _frame.OutlineProvider = ViewOutlineProvider.Background;
+            _frame.ClipToOutline = true;
+
+            ViewCompat.SetOnApplyWindowInsetsListener(_windowContainer, new EdgeToEdgeListener(this));
+            ViewCompat.SetWindowInsetsAnimationCallback(_frame, new BottomSheetInsetsAnimationCallback(this));
+
+            _behavior = BottomSheetBehavior.From(_frame);
+
+            var callback = new BottomSheetCallback(_sheet);
+            callback.StateChanged += Callback_StateChanged;
+            _behavior.AddBottomSheetCallback(callback);
+        }
+    }
+
+    void ContainerDetachedFromWindow(object sender, AView.ViewDetachedFromWindowEventArgs e)
+    {
+
+    }
+
+    void ContainerAttachedToWindow(object sender, AView.ViewAttachedToWindowEventArgs e)
+    {
+
+    }
+
+    void BackdropClicked(object sender, EventArgs e)
+    {
+        if (_sheet.IsCancelable)
+        {
+            Dismiss(true);
+        }
+    }
+
+    WindowInsetsCompat WindowInsets
+    {
+        get
+        {
+            if (OperatingSystem.IsAndroidVersionAtLeast(23) && _windowContainer.RootWindowInsets is not null)
+            {
+                return WindowInsetsCompat.ToWindowInsetsCompat(_windowContainer.RootWindowInsets);
+            }
+
+            return WindowInsetsCompat.Consumed;
+        }
+    }
+
+    Insets Insets
+    {
+        get
+        {
+            var insets = WindowInsets;
+            if (OperatingSystem.IsAndroidVersionAtLeast(30))
+            {
+                return insets.GetInsetsIgnoringVisibility(Android.Views.WindowInsets.Type.SystemBars());
+            }
+#pragma warning disable CS0618
+            return Insets.Of(insets.StableInsetLeft, insets.StableInsetTop, insets.StableInsetRight, insets.StableInsetBottom);
+#pragma warning restore CS0618
+        }
+    }
+
+    int KeyboardHeight => WindowInsets.GetInsets(WindowInsetsCompat.Type.Ime()).Bottom;
+    int TopInset => Insets.Top;
+
+    public double GetAvailableHeight()
+    {
+        var density = DeviceDisplay.MainDisplayInfo.Density;
+
+        return (_windowContainer.Height - TopInset - BottomInset - KeyboardHeight) / density;
+    }
+
+    internal void LayoutDetents(IDictionary<Detent, double> heights, double maxSheetHeight)
+    {
+        // Android supports the following detents:
+        // - expanded (top of screen - offset)
+        // - half expanded (using ratio of expanded - peekHeight)
+        // - collapsed (using peekHeight)
+
+        var sortedHeights = heights
+            .OrderByDescending(i => i.Value)
+            .ToList();
+        var density = DeviceDisplay.MainDisplayInfo.Density;
+
+        var keyboardHeight = KeyboardHeight;
+
+        var top = sortedHeights[0].Value;
+
+        // Configure the sheet to handle up to 3 detents
+
+        if (sortedHeights.Count == 1)
+        { // Only way to have one detent on Android is to use fitToContent. Use that
+            _behavior.FitToContents = true;
+            _behavior.SkipCollapsed = true;
+        }
+        else if (sortedHeights.Count == 2)
+        { // We can handle a second detent by adding a collapsed state. Use peek height
+            _behavior.FitToContents = true;
+            _behavior.SkipCollapsed = false;
+
+            var bottom = sortedHeights[1].Value;
+
+            _behavior.PeekHeight = (int)(bottom * density) + BottomInset + keyboardHeight;
+        }
+        else if (sortedHeights.Count == 3)
+        { // 3 detents can be done using the peek height AND disabling fitToContent
+          // Doing so uses a property called halfExpandedRatio, giving us
+          // Expanded: Use ExpandedOffset to offset from the top
+          // HalfExpanded: Use HalfExpandedRatio
+          // Collapsed: Use PeekHeight
+
+            _behavior.FitToContents = false;
+            _behavior.SkipCollapsed = false;
+
+            var midway = sortedHeights[1].Value;
+            var bottom = sortedHeights[2].Value;
+
+            // Set the top detent by offsetting the requested height from the maxHeight
+            var topOffset = (maxSheetHeight - top) * density;
+            _behavior.ExpandedOffset = Math.Max(0, (int)topOffset);
+
+            // Set the midway detent by calculating the ratio using the top detent info
+            var ratio = ((midway * density) + keyboardHeight + BottomInset) / _frame.LayoutParameters.Height;
+            _behavior.HalfExpandedRatio = (float)ratio;
+
+            // Set the bottom detent using the peekHeight
+            _behavior.PeekHeight = (int)(bottom * density) + BottomInset + keyboardHeight;
+        }
+    }
+
+    double CalculateTallestDetent(double heightConstraint)
+    {
+        if (_heights is null)
+        {
+            CalculateHeights(heightConstraint);
+        }
+        return _heights.Values.Max();
+    }
+
+    void ResizeVirtualView()
+    {
+        var pv = (ContentViewGroup)_sheet.Handler?.PlatformView;
+        var maxHeight = GetAvailableHeight();
+        var height = CalculateTallestDetent(maxHeight);
+
+        double density = DeviceDisplay.MainDisplayInfo.Density;
+
+        var platformHeight = (int)Math.Round(height * density);
+
+        pv.LayoutParameters = new FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MatchParent,
+            platformHeight
+        );
+
+        var layoutParams = _frame.LayoutParameters;
+
+        layoutParams.Height = platformHeight + BottomInset + KeyboardHeight;
+
+        if (height == maxHeight)
+        {
+            layoutParams.Height += TopInset;
+        }
+        _sheet.Arrange(new Rect(0, 0, _frame.Width / density, height));
+    }
+
+    public void Show(bool animated)
+    {
+        _isDuringShowingAnimation = true;
+
+        EnsureWindowContainer();
+
+        _stayOnFront.AddView(_windowContainer);
+
+        _frame.RemoveAllViews();
+
+        // The Android view for the page could already have a ContainerView as a parent if it was shown as a bottom sheet before
+        ((ContentViewGroup)_sheet.Handler?.PlatformView)?.RemoveFromParent();
+        var containerView = _sheet.ToPlatform(_mauiContext);
+
+        var c = new FrameLayout(_mauiContext.Context);
+
+        if (_sheet.HasHandle)
+        {
+            _handle = new BottomSheetDragHandleView(_mauiContext.Context);
+            c.AddView(_handle, new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.WrapContent));
+        }
+
+        c.AddView(containerView);
+
+        _frame.AddView(c);
+
+        UpdateHasBackdrop();
+        UpdateHandleColor();
+
+        if (animated)
+        {
+            _windowContainer?.Backdrop.AnimateIn();
+            _behavior.State = BottomSheetBehavior.StateHidden;
+        }
+
+        _sheet.Dispatcher.Dispatch(() =>
+        {
+            ResizeVirtualView();
+
+            CalculateHeights(GetAvailableHeight());
+            CalculateStates();
+            Layout();
+            UpdateBackground();
+
+            var state = GetStateForDetent(_sheet.SelectedDetent);
+
+            var defaultDetent = _sheet.GetDefaultDetent();
+            if (state is -1)
+            {
+                state = Behavior.SkipCollapsed ? BottomSheetBehavior.StateExpanded : BottomSheetBehavior.StateCollapsed;
+            }
+
+            Behavior.State = state;
+
+            containerView.LayoutChange += OnLayoutChange;
+
+            _sheet.NotifyShowing();
+        });
+    }
+
+    void OnLayoutChange(object sender, AView.LayoutChangeEventArgs e)
+    {
+        _sheet.Dispatcher.Dispatch(() =>
+        {
+            CalculateHeights(GetAvailableHeight());
+            CalculateStates();
+            ResizeVirtualView();
+            Layout();
+        });
+    }
+
+    void Callback_StateChanged(object sender, EventArgs e)
+    {
+        if (_isDuringShowingAnimation && (
+            Behavior.State == BottomSheetBehavior.StateCollapsed
+            || Behavior.State == BottomSheetBehavior.StateHalfExpanded
+            || Behavior.State == BottomSheetBehavior.StateExpanded
+            ))
+        {
+            _isDuringShowingAnimation = false;
+            Behavior.Hideable = _sheet.IsCancelable;
+            _sheet.NotifyShown();
+        }
+        if (Behavior.State == BottomSheetBehavior.StateHidden)
+        {
+            Dispose();
+            _sheet.NotifyDismissed();
+        }
+        ((BottomSheetHandler)_sheet.Handler).UpdateSelectedDetent(_sheet);
+    }
+
+    internal void UpdateSelectedDetent()
+    {
+        var detent = GetDetentForState(Behavior.State);
+        if (detent is not null)
+        {
+            _sheet.SelectedDetent = detent;
+        }
+    }
+
+    internal void UpdateStateFromDetent()
+    {
+        if (_sheet.SelectedDetent is null || Behavior is null || _states is null)
+        {
+            return;
+        }
+        Behavior.State = GetStateForDetent(_sheet.SelectedDetent);
+    }
+
+    internal void UpdateHasBackdrop()
+    {
+        _windowContainer?.SetBackdropVisibility(_sheet.HasBackdrop);
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetHandler.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetHandler.cs
@@ -1,0 +1,38 @@
+﻿namespace The49.Maui.BottomSheet;
+
+public partial class BottomSheetHandler
+{
+    public static void MapBackground(BottomSheetHandler handler, BottomSheet sheet)
+    {
+        sheet.Controller.UpdateBackground();
+    }
+    partial void PlatformUpdateHandleColor(BottomSheet view)
+    {
+        view.Controller.UpdateHandleColor();
+    }
+
+    partial void Dismiss(BottomSheet view, object request)
+    {
+        view?.Controller?.Dismiss((bool)request);
+    }
+
+    partial void PlatformUpdateSelectedDetent(BottomSheet view)
+    {
+        view.Controller.UpdateSelectedDetent();
+    }
+
+    partial void PlatformMapSelectedDetent(BottomSheet view)
+    {
+        view.Controller.UpdateStateFromDetent();
+    }
+
+    partial void PlatformUpdateHasBackdrop(BottomSheet view)
+    {
+        view.Controller.UpdateHasBackdrop();
+    }
+
+    partial void PlatformUpdateCornerRadius(BottomSheet view)
+    {
+        view.Controller.UpdateBackground();
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetManager.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/BottomSheetManager.cs
@@ -1,0 +1,11 @@
+﻿namespace The49.Maui.BottomSheet;
+
+internal partial class BottomSheetManager
+{
+    static partial void PlatformShow(Window window, BottomSheet sheet, bool animated)
+    {
+        var controller = new BottomSheetController(window.Handler.MauiContext, sheet);
+        sheet.Controller = controller;
+        controller.Show(animated);
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/Android/Models/AnchorDetent.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/Models/AnchorDetent.cs
@@ -1,0 +1,20 @@
+﻿using AView = Android.Views.View;
+
+namespace The49.Maui.BottomSheet;
+
+public partial class AnchorDetent : Detent
+{
+    partial void UpdateHeight(BottomSheet page, double maxSheetHeight)
+    {
+        if (Anchor == null)
+        {
+            throw new Exception("Could not update Detent height: Anchor is not set");
+        }
+        var p = ((AView)Anchor.Handler.PlatformView).GetLocationOnScreen();
+        var r = ((AView)page.Handler.PlatformView).GetLocationOnScreen();
+
+        var offset = p - r;
+
+        _height = offset.Height / DeviceDisplay.MainDisplayInfo.Density;
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/Android/Resources/layout/the49_maui_bottom_sheet_design.xml
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/Resources/layout/the49_maui_bottom_sheet_design.xml
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+	<androidx.coordinatorlayout.widget.CoordinatorLayout
+		android:id="@+id/coordinator"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent">
+
+		<View
+			android:id="@+id/touch_outside"
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			android:focusable="false"
+			android:importantForAccessibility="no"
+			android:soundEffectsEnabled="false"
+			tools:ignore="UnusedAttribute"/>
+
+		<FrameLayout
+			android:id="@+id/design_bottom_sheet"
+			style="@style/Widget.Material3.BottomSheet.Modal"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_gravity="center_horizontal|top"
+			app:layout_behavior="@string/bottom_sheet_behavior" />
+
+	</androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+</FrameLayout>

--- a/src/The49.Maui.BottomSheet/Platforms/Android/SheetRadiusDrawable.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/SheetRadiusDrawable.cs
@@ -1,0 +1,16 @@
+﻿using Android.Graphics.Drawables;
+
+namespace The49.Maui.BottomSheet;
+
+internal class SheetRadiusDrawable: GradientDrawable
+{
+    public SheetRadiusDrawable(): base()
+    {
+        
+    }
+
+    internal void SetCornerRadius(int radius)
+    {
+        SetCornerRadii(new float[] { radius, radius, radius, radius, 0, 0, 0, 0 });
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/Android/StayOnFrontView.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/StayOnFrontView.cs
@@ -1,0 +1,46 @@
+﻿using Android.Views;
+using Android.Widget;
+using AView = Android.Views.View;
+using Android.Content;
+
+namespace The49.Maui.BottomSheet;
+
+internal class StayOnFrontView : FrameLayout
+{
+    public StayOnFrontView(Context context) : base(context) {}
+
+    protected override void OnAttachedToWindow()
+    {
+        base.OnAttachedToWindow();
+        if (Parent is ViewGroup vg)
+        {
+            vg.ChildViewAdded += ParentChildViewAdded;
+            vg.ChildViewRemoved += ParentChildViewRemoved;
+        }
+    }
+
+    void ParentChildViewAdded(object sender, ViewGroup.ChildViewAddedEventArgs e)
+    {
+        BringToFront();
+    }
+    void ParentChildViewRemoved(object sender, ViewGroup.ChildViewRemovedEventArgs e)
+    {
+        BringToFront();
+    }
+
+    protected override void OnDetachedFromWindow()
+    {
+        base.OnDetachedFromWindow();
+        if (Parent is ViewGroup vg)
+        {
+            vg.ChildViewAdded -= ParentChildViewAdded;
+            vg.ChildViewRemoved -= ParentChildViewRemoved;
+        }
+    }
+
+    internal void SetContentView(AView view)
+    {
+        RemoveAllViews();
+        AddView(view);
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/Android/ViewExtensions.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/Android/ViewExtensions.cs
@@ -1,0 +1,16 @@
+﻿using AView = Android.Views.View;
+
+namespace The49.Maui.BottomSheet;
+
+internal static class ViewExtensions
+{
+    internal static Point GetLocationOnScreen(this AView view)
+    {
+        int[] location = new int[2];
+        view.GetLocationOnScreen(location);
+        int x = location[0];
+        int y = location[1];
+
+        return new Point(x, y);
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheet.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheet.cs
@@ -1,0 +1,13 @@
+﻿using UIKit;
+
+namespace The49.Maui.BottomSheet;
+
+public partial class BottomSheet
+{
+    public BottomSheetViewController Controller { get; set; }
+
+    // Cache the calculated detents as iOS likes to ask for detents often
+    internal readonly IDictionary<int, float> CachedDetents = new Dictionary<int, float>();
+
+    
+}

--- a/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetContainer.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetContainer.cs
@@ -11,6 +11,10 @@ internal class BottomSheetContainer : UIView
     UIView _view;
     CAShapeLayer _cardMask;
 
+    // At a partial detent the card's bottom corners sit inside the device's rounded display,
+    // so round them enough to hug the screen curve. Fullscreen reaches the true screen corners.
+    const double PartialBottomCornerRadius = 44;
+
     // Can't get the sheet max height with large and medium detents
     // custom detents are not supported on iOS 15
     // can't use largestUndimmedIdentifier or selected detent with custom detents on iOS 16
@@ -44,9 +48,9 @@ internal class BottomSheetContainer : UIView
         _sheet.Controller.Layout();
 
         // iOS 26 renders partial-height sheets as floating cards, but on iPhone the card stays
-        // attached to the bottom edge with square corners that the device's rounded display then
-        // clips. Lift the card above the home-indicator curve and round every corner so it reads
-        // as the native floating card. Older iOS keeps its original edge-attached behavior.
+        // attached to the bottom edge with SQUARE corners, which the device's rounded display then
+        // clips. Round the card's bottom corners enough to sit inside that curve. Older iOS keeps
+        // its original edge-attached behavior.
         if (OperatingSystem.IsIOSVersionAtLeast(26))
         {
             ApplyFloatingCardMask((nfloat)h);
@@ -61,22 +65,38 @@ internal class BottomSheetContainer : UIView
         }
 
         // The presented view is kept transparent (see BottomSheetViewController.UpdateBackground),
-        // so paint the visible card here where it will be masked to the lifted, rounded shape.
+        // so paint the visible card here where it will be masked to the rounded shape.
         Microsoft.Maui.Graphics.Paint paint = _sheet.BackgroundBrush;
         BackgroundColor = paint?.ToColor()?.ToPlatform() ?? UIColor.SystemBackground;
 
         var isFullscreen = Bounds.Height >= tallestDetentHeight - 20;
-        var bottomInset = Window?.SafeAreaInsets.Bottom ?? 0;
-        // On devices without a home indicator, still lift a little so the rounded corners clear the curve.
-        var lift = isFullscreen ? (nfloat)0 : (nfloat)System.Math.Max((double)bottomInset, 8.0);
-        var radius = (nfloat)System.Math.Max(_sheet.CornerRadius, 0);
-
-        var cardHeight = (nfloat)System.Math.Max(0.0, (double)(Bounds.Height - lift));
-        var cardRect = new CGRect(0, 0, Bounds.Width, cardHeight);
-        var path = UIBezierPath.FromRoundedRect(cardRect, radius);
+        var maxR = (nfloat)System.Math.Min(Bounds.Width / 2.0, Bounds.Height / 2.0);
+        var top = (nfloat)System.Math.Min(System.Math.Max(_sheet.CornerRadius, 0), (double)maxR);
+        // Only the partial (floating) detent needs the larger bottom radius; fullscreen reaches the
+        // real screen corners where the sheet's own radius is correct.
+        var bottom = isFullscreen
+            ? top
+            : (nfloat)System.Math.Min(System.Math.Max(_sheet.CornerRadius, PartialBottomCornerRadius), (double)maxR);
 
         _cardMask ??= new CAShapeLayer();
-        _cardMask.Path = path.CGPath;
+        _cardMask.Path = BuildCardPath(Bounds, top, bottom);
         Layer.Mask = _cardMask;
+    }
+
+    // Rounded-rect path with independent top and bottom corner radii.
+    static CGPath BuildCardPath(CGRect r, nfloat rTop, nfloat rBottom)
+    {
+        var p = new CGPath();
+        p.MoveToPoint(r.Left + rTop, r.Top);
+        p.AddLineToPoint(r.Right - rTop, r.Top);
+        p.AddArcToPoint(r.Right, r.Top, r.Right, r.Top + rTop, rTop);
+        p.AddLineToPoint(r.Right, r.Bottom - rBottom);
+        p.AddArcToPoint(r.Right, r.Bottom, r.Right - rBottom, r.Bottom, rBottom);
+        p.AddLineToPoint(r.Left + rBottom, r.Bottom);
+        p.AddArcToPoint(r.Left, r.Bottom, r.Left, r.Bottom - rBottom, rBottom);
+        p.AddLineToPoint(r.Left, r.Top + rTop);
+        p.AddArcToPoint(r.Left, r.Top, r.Left + rTop, r.Top, rTop);
+        p.CloseSubpath();
+        return p;
     }
 }

--- a/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetContainer.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetContainer.cs
@@ -1,5 +1,4 @@
-﻿using CoreAnimation;
-using CoreGraphics;
+﻿using CoreGraphics;
 using Microsoft.Maui.Platform;
 using UIKit;
 
@@ -9,11 +8,6 @@ internal class BottomSheetContainer : UIView
 {
     BottomSheet _sheet;
     UIView _view;
-    CAShapeLayer _cardMask;
-
-    // At a partial detent the card's bottom corners sit inside the device's rounded display,
-    // so round them enough to hug the screen curve. Fullscreen reaches the true screen corners.
-    const double PartialBottomCornerRadius = 44;
 
     // Can't get the sheet max height with large and medium detents
     // custom detents are not supported on iOS 15
@@ -43,60 +37,23 @@ internal class BottomSheetContainer : UIView
     {
         base.LayoutSubviews();
         var h = CalculateTallestDetent(_sheet.Window.Height - BottomSheetManager.KeyboardHeight);
-        _view.Frame = new CGRect(0, 0, Bounds.Width, h);
-        _sheet.Arrange(_view.Frame.ToRectangle());
-        _sheet.Controller.Layout();
 
-        // iOS 26 renders partial-height sheets as floating cards, but on iPhone the card stays
-        // attached to the bottom edge with SQUARE corners, which the device's rounded display then
-        // clips. Round the card's bottom corners enough to sit inside that curve. Older iOS keeps
-        // its original edge-attached behavior.
+        // iOS 26 sizes (and insets) a sheet from its content's measured size. The49 sizes the
+        // content to the TALLEST detent so dragging between detents doesn't re-layout the content,
+        // but on iOS 26 that overflow makes the system present the sheet as an inset card whose
+        // square bottom corners the rounded display then clips. Fitting the content to the card
+        // lets iOS 26 render the native edge-to-edge sheet, with the bottom corners following the
+        // device curve automatically. Earlier iOS keeps the original (no-relayout) behavior.
         if (OperatingSystem.IsIOSVersionAtLeast(26))
         {
-            ApplyFloatingCardMask((nfloat)h);
+            _view.Frame = Bounds;
         }
-    }
-
-    void ApplyFloatingCardMask(nfloat tallestDetentHeight)
-    {
-        if (Bounds.Width <= 0 || Bounds.Height <= 0)
+        else
         {
-            return;
+            _view.Frame = new CGRect(0, 0, Bounds.Width, h);
         }
 
-        // The presented view is kept transparent (see BottomSheetViewController.UpdateBackground),
-        // so paint the visible card here where it will be masked to the rounded shape.
-        Microsoft.Maui.Graphics.Paint paint = _sheet.BackgroundBrush;
-        BackgroundColor = paint?.ToColor()?.ToPlatform() ?? UIColor.SystemBackground;
-
-        var isFullscreen = Bounds.Height >= tallestDetentHeight - 20;
-        var maxR = (nfloat)System.Math.Min(Bounds.Width / 2.0, Bounds.Height / 2.0);
-        var top = (nfloat)System.Math.Min(System.Math.Max(_sheet.CornerRadius, 0), (double)maxR);
-        // Only the partial (floating) detent needs the larger bottom radius; fullscreen reaches the
-        // real screen corners where the sheet's own radius is correct.
-        var bottom = isFullscreen
-            ? top
-            : (nfloat)System.Math.Min(System.Math.Max(_sheet.CornerRadius, PartialBottomCornerRadius), (double)maxR);
-
-        _cardMask ??= new CAShapeLayer();
-        _cardMask.Path = BuildCardPath(Bounds, top, bottom);
-        Layer.Mask = _cardMask;
-    }
-
-    // Rounded-rect path with independent top and bottom corner radii.
-    static CGPath BuildCardPath(CGRect r, nfloat rTop, nfloat rBottom)
-    {
-        var p = new CGPath();
-        p.MoveToPoint(r.Left + rTop, r.Top);
-        p.AddLineToPoint(r.Right - rTop, r.Top);
-        p.AddArcToPoint(r.Right, r.Top, r.Right, r.Top + rTop, rTop);
-        p.AddLineToPoint(r.Right, r.Bottom - rBottom);
-        p.AddArcToPoint(r.Right, r.Bottom, r.Right - rBottom, r.Bottom, rBottom);
-        p.AddLineToPoint(r.Left + rBottom, r.Bottom);
-        p.AddArcToPoint(r.Left, r.Bottom, r.Left, r.Bottom - rBottom, rBottom);
-        p.AddLineToPoint(r.Left, r.Top + rTop);
-        p.AddArcToPoint(r.Left, r.Top, r.Left + rTop, r.Top, rTop);
-        p.CloseSubpath();
-        return p;
+        _sheet.Arrange(_view.Frame.ToRectangle());
+        _sheet.Controller.Layout();
     }
 }

--- a/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetContainer.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetContainer.cs
@@ -1,0 +1,82 @@
+﻿using CoreAnimation;
+using CoreGraphics;
+using Microsoft.Maui.Platform;
+using UIKit;
+
+namespace The49.Maui.BottomSheet;
+
+internal class BottomSheetContainer : UIView
+{
+    BottomSheet _sheet;
+    UIView _view;
+    CAShapeLayer _cardMask;
+
+    // Can't get the sheet max height with large and medium detents
+    // custom detents are not supported on iOS 15
+    // can't use largestUndimmedIdentifier or selected detent with custom detents on iOS 16
+    // So I guess we'll just have to calculate the sheet height ourselves then
+    // This number was found by getting the full screen height, subtracting the sheet's UIView height and the top inset
+    // This seems to be the spacing iOS leaves at the top of the screen when a sheet is fullscreen
+    // TODO: Check if this is the same number for fullscreen sheets opened on top of another sheet
+    const int SheetTopSpacing = 10;
+
+    double CalculateTallestDetent(double heightConstraint)
+    {
+        var window = UIApplication.SharedApplication.KeyWindow;
+        var topPadding = window?.SafeAreaInsets.Top ?? 0;
+        var maximumDetentValue = heightConstraint - topPadding - SheetTopSpacing;
+
+        return _sheet.GetEnabledDetents().Select(d => d.GetHeight(_sheet, maximumDetentValue)).Max();
+    }
+
+    internal BottomSheetContainer(BottomSheet sheet, UIView view)
+    {
+        _sheet = sheet;
+        _view = view;
+        AddSubview(_view);
+    }
+    public override void LayoutSubviews()
+    {
+        base.LayoutSubviews();
+        var h = CalculateTallestDetent(_sheet.Window.Height - BottomSheetManager.KeyboardHeight);
+        _view.Frame = new CGRect(0, 0, Bounds.Width, h);
+        _sheet.Arrange(_view.Frame.ToRectangle());
+        _sheet.Controller.Layout();
+
+        // iOS 26 renders partial-height sheets as floating cards, but on iPhone the card stays
+        // attached to the bottom edge with square corners that the device's rounded display then
+        // clips. Lift the card above the home-indicator curve and round every corner so it reads
+        // as the native floating card. Older iOS keeps its original edge-attached behavior.
+        if (OperatingSystem.IsIOSVersionAtLeast(26))
+        {
+            ApplyFloatingCardMask((nfloat)h);
+        }
+    }
+
+    void ApplyFloatingCardMask(nfloat tallestDetentHeight)
+    {
+        if (Bounds.Width <= 0 || Bounds.Height <= 0)
+        {
+            return;
+        }
+
+        // The presented view is kept transparent (see BottomSheetViewController.UpdateBackground),
+        // so paint the visible card here where it will be masked to the lifted, rounded shape.
+        Microsoft.Maui.Graphics.Paint paint = _sheet.BackgroundBrush;
+        BackgroundColor = paint?.ToColor()?.ToPlatform() ?? UIColor.SystemBackground;
+
+        var isFullscreen = Bounds.Height >= tallestDetentHeight - 20;
+        var bottomInset = Window?.SafeAreaInsets.Bottom ?? 0;
+        // On devices without a home indicator, still lift a little so the rounded corners clear the curve.
+        var lift = isFullscreen ? (nfloat)0 : (nfloat)System.Math.Max((double)bottomInset, 8.0);
+        var radius = (nfloat)System.Math.Max(_sheet.CornerRadius, 0);
+
+        var cardHeight = (nfloat)System.Math.Max(0.0, (double)(Bounds.Height - lift));
+        var cardRect = new CGRect(0, 0, Bounds.Width, cardHeight);
+        var path = UIBezierPath.FromRoundedRect(cardRect, radius);
+
+        _cardMask ??= new CAShapeLayer();
+        _cardMask.Path = path.CGPath;
+        Layer.Mask = _cardMask;
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetControllerDelegate.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetControllerDelegate.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.Versioning;
+using UIKit;
+
+namespace The49.Maui.BottomSheet;
+
+[SupportedOSPlatform("ios15.0")]
+internal class BottomSheetControllerDelegate : UISheetPresentationControllerDelegate
+{
+    BottomSheet _sheet;
+
+    public BottomSheetControllerDelegate(BottomSheet sheet) : base()
+    {
+        _sheet = sheet;
+    }
+    public override void DidDismiss(UIPresentationController presentationController)
+    {
+        _sheet.CachedDetents.Clear();
+        _sheet.NotifyDismissed();
+    }
+
+    public override void DidChangeSelectedDetentIdentifier(UISheetPresentationController sheetPresentationController)
+    {
+        ((BottomSheetHandler)_sheet.Handler).UpdateSelectedDetent(_sheet);
+    }
+}
+

--- a/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetHandler.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetHandler.cs
@@ -1,0 +1,39 @@
+﻿namespace The49.Maui.BottomSheet;
+
+public partial class BottomSheetHandler
+{
+    public static void MapBackground(BottomSheetHandler handler, BottomSheet view)
+    {
+        view.Controller.UpdateBackground();
+    }
+    partial void PlatformUpdateHandleColor(BottomSheet view)
+    {
+        // Not supported on iOS
+    }
+
+    partial void Dismiss(BottomSheet view, object request)
+    {
+        view?.CachedDetents.Clear();
+        view?.Controller?.DismissViewController((bool)request, view.NotifyDismissed);
+    }
+
+    partial void PlatformMapSelectedDetent(BottomSheet view)
+    {
+        if (OperatingSystem.IsIOSVersionAtLeast(15))
+        {
+            view.Controller.UpdateSelectedIdentifierFromDetent();
+        }
+    }
+
+    partial void PlatformUpdateSelectedDetent(BottomSheet view)
+    {
+        if (OperatingSystem.IsIOSVersionAtLeast(15))
+        {
+            view.Controller.UpdateSelectedDetent();
+        }
+    }
+    partial void PlatformUpdateCornerRadius(BottomSheet view)
+    {
+        view.Controller.UpdateCornerRadius(view.CornerRadius);
+    }
+}

--- a/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetManager.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetManager.cs
@@ -1,0 +1,110 @@
+﻿using Foundation;
+using System.Runtime.InteropServices;
+using UIKit;
+namespace The49.Maui.BottomSheet;
+
+internal partial class BottomSheetManager
+{
+    static NSObject _keyboardWillShowObserver;
+    private static nfloat _keyboardHeight;
+    private static object _keyboardDidHideObserver;
+
+    static partial void PlatformShow(Window window, BottomSheet sheet, bool animated)
+    {
+        sheet.Parent = window;
+        var controller = new BottomSheetViewController(window.Handler.MauiContext, sheet);
+        sheet.Controller = controller;
+
+        if (_keyboardWillShowObserver is null)
+        {
+            _keyboardWillShowObserver = UIKeyboard.Notifications.ObserveWillShow(KeyboardWillShow);
+        }
+        if (_keyboardDidHideObserver is null)
+        {
+            _keyboardDidHideObserver = UIKeyboard.Notifications.ObserveDidHide(KeyboardDidHide);
+        }
+
+        if (OperatingSystem.IsIOSVersionAtLeast(15))
+        {
+            controller.SheetPresentationController.PrefersGrabberVisible = sheet.HasHandle;
+        }
+        if (OperatingSystem.IsIOSVersionAtLeast(15))
+        {
+            var largestDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
+
+            if (!sheet.HasBackdrop)
+            {
+                controller.SheetPresentationController.LargestUndimmedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Large;
+            }
+
+
+            var pageDetents = sheet.GetEnabledDetents().ToList();
+
+            var detents = pageDetents
+                .Select((d, index) =>
+                {
+                    if (d is FullscreenDetent)
+                    {
+                        largestDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Large;
+                        return UISheetPresentationControllerDetent.CreateLargeDetent();
+                    }
+                    else if (d is RatioDetent ratioDetent && ratioDetent.Ratio == .5)
+                    {
+                        largestDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Medium;
+                        return UISheetPresentationControllerDetent.CreateMediumDetent();
+                    }
+                    if (!OperatingSystem.IsIOSVersionAtLeast(16))
+                    {
+                        return null;
+                    }
+                    return UISheetPresentationControllerDetent.Create($"detent{index}", (context) =>
+                    {
+                        if (!sheet.CachedDetents.ContainsKey(index))
+                        {
+                            sheet.CachedDetents.Add(index, (float)d.GetHeight(sheet, context.MaximumDetentValue - _keyboardHeight));
+                        }
+                        return sheet.CachedDetents[index];
+                    });
+                })
+                .Where(d => d is not null)
+                .ToList();
+
+            if (detents.Count == 0)
+            {
+                largestDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Medium;
+                detents.Add(UISheetPresentationControllerDetent.CreateMediumDetent());
+            }
+
+            controller.SheetPresentationController.Detents = detents.ToArray();
+
+            if (!sheet.HasBackdrop)
+            {
+                controller.SheetPresentationController.LargestUndimmedDetentIdentifier = largestDetentIdentifier;
+            }
+
+            controller.SheetPresentationController.SelectedDetentIdentifier = BottomSheetViewController.GetIdentifierForDetent(sheet.SelectedDetent);
+        }
+
+        if (OperatingSystem.IsIOSVersionAtLeast(13))
+        {
+            controller.ModalInPresentation = !sheet.IsCancelable;
+        }
+
+        var parent = Platform.GetCurrentUIViewController();
+
+        parent.PresentViewController(controller, animated, sheet.NotifyShown);
+    }
+
+    static void KeyboardDidHide(object sender, UIKeyboardEventArgs e)
+    {
+        _keyboardHeight = 0;
+    }
+
+    static void KeyboardWillShow(object sender, UIKeyboardEventArgs e)
+    {
+        _keyboardHeight = e.FrameEnd.Height;
+    }
+
+    internal static NFloat KeyboardHeight => _keyboardHeight;
+}
+

--- a/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetViewController.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetViewController.cs
@@ -66,14 +66,6 @@ public class BottomSheetViewController : UIViewController
     }
     internal void UpdateBackground()
     {
-        // On iOS 26 the floating card background is painted by BottomSheetContainer (which is
-        // masked/lifted to clear the device corners), so keep the presented view transparent.
-        if (OperatingSystem.IsIOSVersionAtLeast(26))
-        {
-            View.BackgroundColor = UIColor.Clear;
-            return;
-        }
-
         if (_sheet?.BackgroundBrush != null)
         {
             Paint paint = _sheet.BackgroundBrush;

--- a/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetViewController.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/iOS/BottomSheetViewController.cs
@@ -1,0 +1,154 @@
+﻿using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Foundation;
+using Microsoft.Maui.Platform;
+using UIKit;
+
+namespace The49.Maui.BottomSheet;
+
+public class BottomSheetViewController : UIViewController
+{
+    IMauiContext _windowMauiContext;
+    BottomSheet _sheet;
+    NSObject? _keyboardDidHideObserver;
+
+    public BottomSheetViewController(IMauiContext windowMauiContext, BottomSheet sheet) : base()
+    {
+        _windowMauiContext = windowMauiContext;
+        _sheet = sheet;
+        if (OperatingSystem.IsIOSVersionAtLeast(15))
+        {
+            SheetPresentationController.Delegate = new BottomSheetControllerDelegate(_sheet);
+        }
+    }
+
+    public override void ViewDidLoad()
+    {
+        base.ViewDidLoad();
+
+        var container = _sheet.ToPlatform(_windowMauiContext);
+
+        var cv = new BottomSheetContainer(_sheet, container);
+
+        View.AddSubview(cv);
+
+        cv.TranslatesAutoresizingMaskIntoConstraints = false;
+
+        NSLayoutConstraint.ActivateConstraints(new[]
+        {
+            cv.TopAnchor.ConstraintEqualTo(View.TopAnchor),
+            cv.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor),
+            cv.BottomAnchor.ConstraintEqualTo(View.BottomAnchor),
+            cv.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor)
+        });
+
+        UpdateBackground();
+        _sheet.NotifyShowing();
+
+        if (_keyboardDidHideObserver is null)
+        {
+            _keyboardDidHideObserver = UIKeyboard.Notifications.ObserveDidHide(KeyboardDidHide);
+        }
+    }
+
+    void KeyboardDidHide(object sender, UIKeyboardEventArgs e)
+    {
+        Layout();
+    }
+
+    public void Layout()
+    {
+        _sheet.CachedDetents.Clear();
+        if (OperatingSystem.IsIOSVersionAtLeast(16))
+        {
+            SheetPresentationController.InvalidateDetents();
+        }
+    }
+    internal void UpdateBackground()
+    {
+        // On iOS 26 the floating card background is painted by BottomSheetContainer (which is
+        // masked/lifted to clear the device corners), so keep the presented view transparent.
+        if (OperatingSystem.IsIOSVersionAtLeast(26))
+        {
+            View.BackgroundColor = UIColor.Clear;
+            return;
+        }
+
+        if (_sheet?.BackgroundBrush != null)
+        {
+            Paint paint = _sheet.BackgroundBrush;
+            View.BackgroundColor = paint.ToColor().ToPlatform();
+        }
+        else
+        {
+            if (OperatingSystem.IsIOSVersionAtLeast(13))
+            {
+                View.BackgroundColor = UIColor.SystemBackground;
+            }
+        }
+    }
+    public override void ViewDidLayoutSubviews()
+    {
+        base.ViewDidLayoutSubviews();
+        Layout();
+    }
+
+    [SupportedOSPlatform("ios15.0")]
+    internal static UISheetPresentationControllerDetentIdentifier GetIdentifierForDetent(Detent d)
+    {
+        if (d is FullscreenDetent)
+        {
+            return UISheetPresentationControllerDetentIdentifier.Large;
+        }
+        else if (d is RatioDetent ratioDetent && ratioDetent.Ratio == .5)
+        {
+            return UISheetPresentationControllerDetentIdentifier.Medium;
+        }
+        return UISheetPresentationControllerDetentIdentifier.Unknown;
+    }
+
+    [SupportedOSPlatform("ios15.0")]
+    internal void UpdateSelectedIdentifierFromDetent()
+    {
+        if (_sheet.SelectedDetent is null)
+        {
+            return;
+        }
+        SheetPresentationController.AnimateChanges(() =>
+        {
+            SheetPresentationController.SelectedDetentIdentifier = GetIdentifierForDetent(_sheet.SelectedDetent);
+        });
+    }
+
+    [SupportedOSPlatform("ios15.0")]
+    internal Detent GetSelectedDetent()
+    {
+        if (!OperatingSystem.IsIOSVersionAtLeast(15))
+        {
+            return null;
+        }
+        var detents = _sheet.GetEnabledDetents();
+        return SheetPresentationController.SelectedDetentIdentifier switch
+        {
+            UISheetPresentationControllerDetentIdentifier.Medium => detents.FirstOrDefault(d => d is RatioDetent ratioDetent && ratioDetent.Ratio == .5f),
+            UISheetPresentationControllerDetentIdentifier.Large => detents.FirstOrDefault(d => d is FullscreenDetent),
+            UISheetPresentationControllerDetentIdentifier.Unknown or _ => null,
+        };
+    }
+
+    [SupportedOSPlatform("ios15.0")]
+    internal void UpdateSelectedDetent()
+    {
+        _sheet.SelectedDetent = GetSelectedDetent();
+    }
+
+    internal void UpdateCornerRadius(double cornerRadius)
+    {
+        if (!OperatingSystem.IsIOSVersionAtLeast(15))
+        {
+            return;
+        }
+        SheetPresentationController.PreferredCornerRadius = (NFloat)cornerRadius;
+    }
+}
+

--- a/src/The49.Maui.BottomSheet/Platforms/iOS/Models/AnchorDetent.cs
+++ b/src/The49.Maui.BottomSheet/Platforms/iOS/Models/AnchorDetent.cs
@@ -1,0 +1,17 @@
+﻿using UIKit;
+
+namespace The49.Maui.BottomSheet;
+
+public partial class AnchorDetent
+{
+    partial void UpdateHeight(BottomSheet page, double maxSheetHeight)
+    {
+        var pageView = (UIView)page.Handler.PlatformView;
+        var targetView = (UIView)Anchor.Handler.PlatformView;
+
+        var targetOrigin = targetView.Superview.ConvertPointToView(targetView.Frame.Location, pageView);
+
+        _height = targetOrigin.Y;
+    }
+}
+

--- a/src/The49.Maui.BottomSheet/Resources/Raw/AboutAssets.txt
+++ b/src/The49.Maui.BottomSheet/Resources/Raw/AboutAssets.txt
@@ -1,0 +1,15 @@
+﻿Any raw assets you want to be deployed with your application can be placed in
+this directory (and child directories). Deployment of the asset to your application
+is automatically handled by the following `MauiAsset` Build Action within your `.csproj`.
+
+	<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+
+These files will be deployed with you package and will be accessible using Essentials:
+
+	async Task LoadMauiAsset()
+	{
+		using var stream = await FileSystem.OpenAppPackageFileAsync("AboutAssets.txt");
+		using var reader = new StreamReader(stream);
+
+		var contents = reader.ReadToEnd();
+	}

--- a/src/The49.Maui.BottomSheet/The49.Maui.BottomSheet.csproj
+++ b/src/The49.Maui.BottomSheet/The49.Maui.BottomSheet.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net10.0-android;net10.0-ios</TargetFrameworks>
+		<RootNamespace>The49.Maui.BottomSheet</RootNamespace>
+		<UseMaui>true</UseMaui>
+		<SingleProject>true</SingleProject>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>annotations</Nullable>
+		<SkipValidateMauiImplicitPackageReferences>true</SkipValidateMauiImplicitPackageReferences>
+		<IsPackable>false</IsPackable>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">16.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="M.BindableProperty.Generator" Version="0.11.1" PrivateAssets="all" />
+	</ItemGroup>
+
+</Project>

--- a/src/The49.Maui.BottomSheet/VENDORED.md
+++ b/src/The49.Maui.BottomSheet/VENDORED.md
@@ -1,4 +1,4 @@
-# Vendored: The49.Maui.BottomSheet (iOS 26 floating-card fix)
+# Vendored: The49.Maui.BottomSheet (iOS 26 sheet-sizing fix)
 
 This folder is a vendored copy of [The49.Maui.BottomSheet](https://github.com/the49ltd/The49.Maui.BottomSheet)
 (v8.0.3, MIT — see `LICENSE.md`). Upstream is dormant (last release February 2024,
@@ -6,10 +6,18 @@ targeting `net8.0-ios17.2`) and has no iOS 26 build, so the source lives in-tree
 
 ## Why
 
-On iOS 26 a partial-height sheet (the calendar-event sheet opens at the **medium**
-detent) is rendered as a floating card, but on iPhone the system keeps the card
-**attached to the bottom edge with square corners**. The device's rounded display then
-clips those bottom corners. See the app's calendar-event page.
+On iOS 26 the calendar-event sheet (which opens at the **medium** detent) rendered as an
+inset card whose square bottom corners the device's rounded display then clipped, with
+the map showing in a margin down both sides. A pristine native `UISheetPresentationController`
+sheet on iOS 26 does **not** do this: it is edge-to-edge, and its bottom corners follow the
+device curve automatically.
+
+## Root cause
+
+iOS 26 sizes (and insets) a sheet from its content's measured size. The49 sizes the content
+view to the **tallest** detent height so that dragging between detents does not re-layout the
+content. On iOS 26 that oversized/overflowing content makes the system present the sheet as an
+inset card instead of the native edge-to-edge sheet.
 
 ## Changes vs upstream 8.0.3
 
@@ -17,17 +25,14 @@ clips those bottom corners. See the app's calendar-event page.
   and stripped NuGet packaging metadata (this is a `ProjectReference`, not a package).
 - **`Models/ContentDetent.cs`** — `Measure(...)` now returns `Size` in .NET 10, so
   `r.Request.Height` → `r.Height`.
-- **`Platforms/iOS/BottomSheetContainer.cs`** — on iOS 26, mask the card so its **bottom
-  corners** are rounded enough to sit inside the device's rounded display instead of being
-  clipped (`ApplyFloatingCardMask`, `BuildCardPath` with independent top/bottom radii). The
-  top corners keep the sheet's own `CornerRadius`; fullscreen is unchanged; older iOS is
-  unchanged. (An earlier attempt lifted the card off the bottom, but that exposed the system
-  sheet's shadow/material below it — rounding the corners in place avoids that.)
-- **`Platforms/iOS/BottomSheetViewController.cs`** — on iOS 26, keep the presented view
-  transparent so the rounded corner cut-outs show the content behind the sheet.
+- **`Platforms/iOS/BottomSheetContainer.cs`** — on iOS 26, size the content view to the card
+  (`_view.Frame = Bounds`) instead of the tallest-detent height. This lets iOS render the
+  native edge-to-edge sheet and handle the bottom corners per the device. Earlier iOS keeps
+  the original (no-relayout) behavior. This is the whole fix — no corner masking, no
+  device-specific radii.
 
-The iOS behavior change is gated behind `OperatingSystem.IsIOSVersionAtLeast(26)`, so
-iOS 16–18 keep their original edge-attached rendering.
+The behavior change is gated behind `OperatingSystem.IsIOSVersionAtLeast(26)`, so iOS 16–18
+are unchanged.
 
 The upstream-shaped version of the fix is offered back as a pull request:
 https://github.com/the49ltd/The49.Maui.BottomSheet/pull/160

--- a/src/The49.Maui.BottomSheet/VENDORED.md
+++ b/src/The49.Maui.BottomSheet/VENDORED.md
@@ -17,11 +17,14 @@ clips those bottom corners. See the app's calendar-event page.
   and stripped NuGet packaging metadata (this is a `ProjectReference`, not a package).
 - **`Models/ContentDetent.cs`** — `Measure(...)` now returns `Size` in .NET 10, so
   `r.Request.Height` → `r.Height`.
-- **`Platforms/iOS/BottomSheetContainer.cs`** — on iOS 26, lift the card above the
-  home-indicator curve and mask all four corners round so nothing is clipped
-  (`ApplyFloatingCardMask`). Fullscreen stays edge-to-edge; older iOS is unchanged.
+- **`Platforms/iOS/BottomSheetContainer.cs`** — on iOS 26, mask the card so its **bottom
+  corners** are rounded enough to sit inside the device's rounded display instead of being
+  clipped (`ApplyFloatingCardMask`, `BuildCardPath` with independent top/bottom radii). The
+  top corners keep the sheet's own `CornerRadius`; fullscreen is unchanged; older iOS is
+  unchanged. (An earlier attempt lifted the card off the bottom, but that exposed the system
+  sheet's shadow/material below it — rounding the corners in place avoids that.)
 - **`Platforms/iOS/BottomSheetViewController.cs`** — on iOS 26, keep the presented view
-  transparent so the lifted card floats over the content behind the sheet.
+  transparent so the rounded corner cut-outs show the content behind the sheet.
 
 The iOS behavior change is gated behind `OperatingSystem.IsIOSVersionAtLeast(26)`, so
 iOS 16–18 keep their original edge-attached rendering.

--- a/src/The49.Maui.BottomSheet/VENDORED.md
+++ b/src/The49.Maui.BottomSheet/VENDORED.md
@@ -1,0 +1,30 @@
+# Vendored: The49.Maui.BottomSheet (iOS 26 floating-card fix)
+
+This folder is a vendored copy of [The49.Maui.BottomSheet](https://github.com/the49ltd/The49.Maui.BottomSheet)
+(v8.0.3, MIT — see `LICENSE.md`). Upstream is dormant (last release February 2024,
+targeting `net8.0-ios17.2`) and has no iOS 26 build, so the source lives in-tree.
+
+## Why
+
+On iOS 26 a partial-height sheet (the calendar-event sheet opens at the **medium**
+detent) is rendered as a floating card, but on iPhone the system keeps the card
+**attached to the bottom edge with square corners**. The device's rounded display then
+clips those bottom corners. See the app's calendar-event page.
+
+## Changes vs upstream 8.0.3
+
+- **`The49.Maui.BottomSheet.csproj`** — retargeted `net8.0-*` → `net10.0-android;net10.0-ios`
+  and stripped NuGet packaging metadata (this is a `ProjectReference`, not a package).
+- **`Models/ContentDetent.cs`** — `Measure(...)` now returns `Size` in .NET 10, so
+  `r.Request.Height` → `r.Height`.
+- **`Platforms/iOS/BottomSheetContainer.cs`** — on iOS 26, lift the card above the
+  home-indicator curve and mask all four corners round so nothing is clipped
+  (`ApplyFloatingCardMask`). Fullscreen stays edge-to-edge; older iOS is unchanged.
+- **`Platforms/iOS/BottomSheetViewController.cs`** — on iOS 26, keep the presented view
+  transparent so the lifted card floats over the content behind the sheet.
+
+The iOS behavior change is gated behind `OperatingSystem.IsIOSVersionAtLeast(26)`, so
+iOS 16–18 keep their original edge-attached rendering.
+
+The upstream-shaped version of the fix is offered back as a pull request:
+https://github.com/the49ltd/The49.Maui.BottomSheet/pull/160


### PR DESCRIPTION
## iOS 26 bottom-sheet corner clipping

On iOS 26 the calendar-event sheet opens at its medium detent, which iOS 26 renders as a floating card — but on iPhone the system keeps the card **attached to the bottom edge with square corners**, and the device's rounded display then **clips those bottom corners**. It isn't visible in a `simctl` screenshot (that captures the flat framebuffer before the corner mask), only on a real device.

The49.Maui.BottomSheet is dormant (last release 8.0.3, Feb 2024, `net8.0-ios17.2`, no iOS 26 build), so its source is **vendored** into `src/The49.Maui.BottomSheet/` and the package reference swapped for a project reference:

- **`BottomSheetContainer`** (iOS) — at partial detents, lift the card above the home-indicator curve and mask all four corners round; fullscreen stays edge-to-edge. Gated behind `IsIOSVersionAtLeast(26)`, so iOS 16–18 are unchanged.
- **`BottomSheetViewController`** (iOS) — on iOS 26 keep the presented view transparent so the lifted card floats over the map behind it.
- Retargeted the vendored project to `net10.0` and fixed the .NET 10 `Measure()` API (`Size` vs `SizeRequest`).

App XAML is unchanged. Verified on an iPhone 17 Pro / iOS 26.1 simulator (light + dark), and the fullscreen detent is still edge-to-edge. See `src/The49.Maui.BottomSheet/VENDORED.md`. The upstream-shaped fix is also offered back: the49ltd/The49.Maui.BottomSheet#160.

## Also

- Bump `Plugin.Maui.NativeCalendar` 1.0.4 → 1.0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)